### PR TITLE
fix: RosterFeed scrollt beim Öffnen automatisch zum heutigen Tag

### DIFF
--- a/src/components/RosterFeed.jsx
+++ b/src/components/RosterFeed.jsx
@@ -70,6 +70,20 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
 
     const { getHoliday } = useHolidays()
 
+    // Scroll to today's DayCard when the current month is loaded
+    useEffect(() => {
+        if (!isSameMonth(currentDate, new Date())) return
+        const todayStr = format(new Date(), 'yyyy-MM-dd')
+        if (!visibleShiftsByDate[todayStr]) return
+        requestAnimationFrame(() => {
+            const container = document.getElementById('roster-scroll-container')
+            const todayEl = document.getElementById(`day-${todayStr}`)
+            if (container && todayEl) {
+                container.scrollTop = todayEl.offsetTop - 16
+            }
+        })
+    }, [visibleShiftsByDate, currentDate])
+
     // 1. Daten Laden
     const fetchData = async () => {
         const monthStart = startOfMonth(currentDate)
@@ -1085,8 +1099,8 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
                                                 const holiday = getHoliday(new Date(dateStr))
 
                                                 return (
+                                                    <div key={dateStr} id={`day-${dateStr}`}>
                                                     <DayCard
-                                                        key={dateStr}
                                                         dateStr={dateStr}
                                                         shifts={visibleShiftsByDate[dateStr]}
                                                         userId={user.id}
@@ -1180,6 +1194,7 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
                                                         onCoverageVote={submitCoverageVote}
                                                         onCoverageResolve={resolveAllCoverageRequests}
                                                     />
+                                                    </div>
                                                 )
                                             })}
                                         </>


### PR DESCRIPTION
fixes #61

## Zusammenfassung

- DayCard-Wrapper bekommen `id="day-YYYY-MM-DD"` für direkten DOM-Zugriff
- Neuer `useEffect` scrollt `#roster-scroll-container` sofort zum heutigen Tag, wenn der aktuelle Monat angezeigt wird
- Beim Navigieren zu anderen Monaten kein Auto-Scroll
- Beim Zurücknavigieren zum aktuellen Monat scrollt es erneut zu heute

## Test-Plan

- [ ] App im Browser auf mobilem Viewport öffnen → heutiger Tag ist sofort sichtbar
- [ ] Zum nächsten Monat navigieren → kein Auto-Scroll
- [ ] Zurück zum aktuellen Monat → scrollt wieder zu heute
- [ ] `npm run build` — kein Fehler
- [ ] `npm test` — alle 645 Tests grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)