### PR TITLE
fix: Minimap bei offenem ActionSheet ausblenden + ActionSheet zentrieren (#67)

### DIFF
--- a/src/components/ActionSheet.jsx
+++ b/src/components/ActionSheet.jsx
@@ -18,7 +18,7 @@ export default function ActionSheet({ isOpen, onClose, title, children }) {
     if (!visible && !isOpen) return null
 
     return (
-        <div className="fixed inset-0 z-[200] flex items-end justify-center sm:items-center">
+        <div className="fixed inset-0 z-[200] flex items-center justify-center">
             {/* Backdrop */}
             <div
                 className={`fixed inset-0 bg-black/40 backdrop-blur-sm transition-opacity duration-300 ${isOpen ? 'opacity-100' : 'opacity-0'}`}
@@ -27,7 +27,7 @@ export default function ActionSheet({ isOpen, onClose, title, children }) {
 
             {/* Sheet */}
             <div
-                className={`bg-white w-full max-w-md sm:rounded-2xl rounded-t-2xl shadow-2xl transform transition-transform duration-300 ease-out max-h-[90vh] overflow-y-auto ${isOpen ? 'translate-y-0 sm:scale-100' : 'translate-y-full sm:translate-y-0 sm:scale-95'}`}
+                className={`bg-white w-full max-w-md rounded-2xl shadow-2xl transform transition-all duration-300 ease-out max-h-[90vh] overflow-y-auto ${isOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'}`}
             >
                 <div className="sticky top-0 bg-white border-b border-gray-100 px-4 py-3 flex justify-between items-center z-10">
                     <h3 className="font-bold text-lg text-gray-900">{title}</h3>

--- a/src/components/RosterFeed.jsx
+++ b/src/components/RosterFeed.jsx
@@ -1091,7 +1091,9 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
                                         />
                                     ) : (
                                         <>
-                                            <MonthMinimap shifts={shifts} currentDate={currentDate} userId={user.id} absences={allAbsences} headerRef={stickyHeaderRef} />
+                                            {!isBalanceExpanded && (
+                                                <MonthMinimap shifts={shifts} currentDate={currentDate} userId={user.id} absences={allAbsences} headerRef={stickyHeaderRef} />
+                                            )}
                                             {Object.keys(visibleShiftsByDate).length === 0 && (
                                                 <div className="text-center mt-10">
                                                     <p className="text-gray-400 mb-4">Keine Dienste für {format(currentDate, 'MMMM', { locale: de })} gefunden.</p>


### PR DESCRIPTION
fixes #67

## Änderungen

- **RosterFeed.jsx**: MonthMinimap in `{!isBalanceExpanded && ...}` eingewickelt — verschwindet wenn Stundenkonto-ActionSheet offen ist
- **ActionSheet.jsx**: `items-end` → `items-center` (zentriert auf allen Bildschirmgrößen)
- **ActionSheet.jsx**: Animation von `translate-y-full` (slide-from-bottom) auf `opacity+scale` geändert — passt zum Stil von AlertModal/ConfirmModal
- **ActionSheet.jsx**: `rounded-t-2xl` → `rounded-2xl` (volle Rundung bei zentriertem Modal)

## Betroffene Dateien

- `src/components/ActionSheet.jsx`
- `src/components/RosterFeed.jsx`