### PR TITLE
fix: RosterFeed scroll-to-today nur beim App-Start (#78)

### DIFF
--- a/src/components/RosterFeed.jsx
+++ b/src/components/RosterFeed.jsx
@@ -49,6 +49,7 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
     const [viewMode, setViewMode] = useState('cards') // 'cards' or 'table'
     const [currentDate, setCurrentDate] = useState(new Date())
     const [isMonthOpen, setIsMonthOpen] = useState(false)
+    const hasScrolledToToday = useRef(false)
     const [isMonthVisible, setIsMonthVisible] = useState(true)
     const [isSickModalOpen, setIsSickModalOpen] = useState(false)
     const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
@@ -379,11 +380,13 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
         return filtered
     }, [shiftsByDate, currentDate, isAdmin, isMonthVisible])
 
-    // Scroll to today's DayCard when the current month is loaded
+    // Scroll to today's DayCard only on initial load (app open)
     useEffect(() => {
+        if (hasScrolledToToday.current) return
         if (!isSameMonth(currentDate, new Date())) return
         const todayStr = format(new Date(), 'yyyy-MM-dd')
         if (!visibleShiftsByDate[todayStr]) return
+        hasScrolledToToday.current = true
         requestAnimationFrame(() => {
             const container = document.getElementById('roster-scroll-container')
             const todayEl = document.getElementById(`day-${todayStr}`)


### PR DESCRIPTION
## Summary\n\n- **fixes #78** — RosterFeed springt nicht mehr bei jedem Shift-Klick zum aktuellen Tag zurück\n- `useRef`-Guard (`hasScrolledToToday`) sorgt dafür, dass der scroll-to-today Effect nur einmal beim ersten Laden feuert\n\n## Test plan\n\n- [ ] App öffnen → RosterFeed scrollt zum heutigen Tag\n- [ ] Auf einen Dienst klicken → Ansicht bleibt an der aktuellen Scroll-Position\n- [ ] Monat wechseln und zurück → kein erneuter Auto-Scroll\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed roster feed to properly scroll to today's date on initial load without unnecessary re-triggering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->