### PR TITLE
feat: Zuschauer-Rolle (Viewer) für read-only Zugang

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,7 +37,7 @@ import { RosterFeedSkeleton, TimeTrackingSkeleton, ProfileSkeleton, PageSkeleton
 const LazyLoadFallback = () => <PageSkeleton />
 
 function AppContent() {
-  const { user, isAdmin, passwordSet, refreshPasswordSet } = useAuth()
+  const { user, isAdmin, isViewer, passwordSet, refreshPasswordSet } = useAuth()
   const [activeTab, setActiveTab] = useState('roster')
   const [calendarDate, setCalendarDate] = useState(null)
   const [badges, setBadges] = useState({})
@@ -96,7 +96,7 @@ function AppContent() {
 
   // Fetch open coverage requests for non-admin users (only when voting system is active)
   const refreshCoverageCount = async () => {
-    if (!USE_COVERAGE_VOTING || !user || isAdmin) {
+    if (!USE_COVERAGE_VOTING || !user || isAdmin || isViewer) {
       setOpenCoverageCount(0)
       return
     }
@@ -128,7 +128,7 @@ function AppContent() {
   }
 
   useEffect(() => {
-    if (!USE_COVERAGE_VOTING || !user || isAdmin) {
+    if (!USE_COVERAGE_VOTING || !user || isAdmin || isViewer) {
       setOpenCoverageCount(0)
       return
     }
@@ -149,7 +149,14 @@ function AppContent() {
       })
 
     return () => { supabase.removeChannel(channel) }
-  }, [user, isAdmin])
+  }, [user, isAdmin, isViewer])
+
+  // Redirect viewer away from forbidden tabs
+  useEffect(() => {
+    if (isViewer && (activeTab === 'times' || activeTab === 'admin')) {
+      setActiveTab('roster')
+    }
+  }, [isViewer, activeTab])
 
   const handleNavigateToCalendar = (date) => {
     setCalendarDate(new Date(date))
@@ -170,13 +177,13 @@ function AppContent() {
       <ReloadPrompt />
 
       {/* Desktop Sidebar (Hidden on Mobile) */}
-      <Sidebar activeTab={activeTab} onTabChange={setActiveTab} isAdmin={isAdmin} badges={badges} />
+      <Sidebar activeTab={activeTab} onTabChange={setActiveTab} isAdmin={isAdmin} isViewer={isViewer} badges={badges} />
 
       {/* Main Content Wrapper */}
       <div className="flex-1 flex flex-col h-screen overflow-hidden relative bg-slate-50">
 
         {/* Coverage Alert Banner - shown on all tabs (only with voting system) */}
-        {USE_COVERAGE_VOTING && openCoverageCount > 0 && (
+        {USE_COVERAGE_VOTING && !isViewer && openCoverageCount > 0 && (
           <button
             onClick={() => {
               if (activeTab !== 'roster') {
@@ -200,7 +207,7 @@ function AppContent() {
         <div className={`flex-1 ${activeTab === 'roster' ? 'overflow-hidden' : 'overflow-y-auto'} scrollbar-hide pb-20 md:pb-0`}>
 
           {activeTab === 'roster' && <RosterFeed onCoverageVoteChanged={refreshCoverageCount} />}
-          {activeTab === 'times' && (
+          {activeTab === 'times' && !isViewer && (
             <Suspense fallback={<TimeTrackingSkeleton />}>
               {isAdmin ? <AdminTimeTracking /> : (USE_NEW_TIME_TRACKING ? <TimeTrackingV2 /> : <TimeTracking />)}
             </Suspense>
@@ -224,7 +231,7 @@ function AppContent() {
 
         {/* Bottom Nav (Mobile Only) */}
         <div className="md:hidden fixed bottom-0 left-0 right-0">
-          <BottomNav activeTab={activeTab} onTabChange={setActiveTab} isAdmin={isAdmin} badges={badges} />
+          <BottomNav activeTab={activeTab} onTabChange={setActiveTab} isAdmin={isAdmin} isViewer={isViewer} badges={badges} />
         </div>
       </div>
     </div>

--- a/src/AuthContext.jsx
+++ b/src/AuthContext.jsx
@@ -114,6 +114,7 @@ export const AuthProvider = ({ children }) => {
 
 
     const isAdmin = role === 'admin'
+    const isViewer = role === 'viewer'
 
     // Function to refresh password_set status after user sets their password
     const refreshPasswordSet = () => {
@@ -130,7 +131,7 @@ export const AuthProvider = ({ children }) => {
     }
 
     return (
-        <AuthContext.Provider value={{ user, role, isAdmin, loading, passwordSet, refreshPasswordSet }}>
+        <AuthContext.Provider value={{ user, role, isAdmin, isViewer, loading, passwordSet, refreshPasswordSet }}>
             {children}
         </AuthContext.Provider>
     )

--- a/src/components/AbsencePlanner.jsx
+++ b/src/components/AbsencePlanner.jsx
@@ -19,7 +19,7 @@ import { useToast } from './Toast'
 import { handleError } from '../utils/errorHandler'
 
 export default function AbsencePlanner({ initialDate }) {
-    const { user, isAdmin } = useAuth()
+    const { user, isAdmin, isViewer } = useAuth()
     const [currentMonth, setCurrentMonth] = useState(initialDate || new Date())
     const [absences, setAbsences] = useState([])
     const [confirmConfig, setConfirmConfig] = useState({ isOpen: false, title: '', message: '', onConfirm: () => { } })
@@ -129,7 +129,7 @@ export default function AbsencePlanner({ initialDate }) {
 
     // Click Handler
     const handleDayClick = (day) => {
-        if (isAdmin) return
+        if (isAdmin || isViewer) return
         if (!selectionStart || (selectionStart && selectionEnd)) {
             setSelectionStart(day)
             setSelectionEnd(null)
@@ -526,7 +526,7 @@ export default function AbsencePlanner({ initialDate }) {
             </div>
 
             {/* Floating Action Button for Request */}
-            {selectionStart && (
+            {selectionStart && !isViewer && (
                 <div className="mt-4 mx-4 z-40 animate-in slide-in-from-bottom-4 fade-in duration-300 shrink-0">
                     <button
                         onClick={handleSave}
@@ -588,7 +588,7 @@ export default function AbsencePlanner({ initialDate }) {
                                                     <Download size={18} />
                                                 </button>
                                             )}
-                                            {req.status === 'beantragt' && (
+                                            {req.status === 'beantragt' && !isViewer && (
                                                 <button onClick={() => handleDelete(req.id)} className="p-2 text-gray-300 hover:text-red-500 transition-colors">
                                                     <Trash2 size={18} />
                                                 </button>

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -33,7 +33,7 @@ function NavItem({ id, icon: Icon, label, isActive, onClick, badge }) {
     )
 }
 
-export default function BottomNav({ activeTab, onTabChange, isAdmin, badges = {} }) {
+export default function BottomNav({ activeTab, onTabChange, isAdmin, isViewer, badges = {} }) {
     // badges = { roster: { dot: true }, admin: { count: 3 }, ... }
 
     return (
@@ -46,6 +46,7 @@ export default function BottomNav({ activeTab, onTabChange, isAdmin, badges = {}
                 onClick={onTabChange}
                 badge={badges.roster}
             />
+            {!isViewer && (
             <NavItem
                 id="times"
                 icon={List}
@@ -54,6 +55,7 @@ export default function BottomNav({ activeTab, onTabChange, isAdmin, badges = {}
                 onClick={onTabChange}
                 badge={badges.times}
             />
+            )}
             <NavItem
                 id="absences"
                 icon={Plane}

--- a/src/components/DayCard.jsx
+++ b/src/components/DayCard.jsx
@@ -33,7 +33,7 @@ const getUserColor = (name) => {
     return colors[Math.abs(hash) % colors.length]
 }
 
-export default function DayCard({ dateStr, shifts, userId, onToggleInterest, onToggleFlex, onUpdateShift, onDeleteShift, onCreateShift, isAdmin, absenceReason, holiday, absences = [], allProfiles = [], coverageRequests = [], coverageVotes = [], fairnessIndices = [], userBalance = null, onCoverageVote, onCoverageResolve, onDirectTakeover }) {
+export default function DayCard({ dateStr, shifts, userId, onToggleInterest, onToggleFlex, onUpdateShift, onDeleteShift, onCreateShift, isAdmin, isViewer, absenceReason, holiday, absences = [], allProfiles = [], coverageRequests = [], coverageVotes = [], fairnessIndices = [], userBalance = null, onCoverageVote, onCoverageResolve, onDirectTakeover }) {
     // ALL HOOKS MUST BE CALLED BEFORE ANY CONDITIONAL RETURNS
     const [selectedShift, setSelectedShift] = useState(null)
     const [isAddMenuOpen, setIsAddMenuOpen] = useState(false)
@@ -111,6 +111,7 @@ export default function DayCard({ dateStr, shifts, userId, onToggleInterest, onT
     }
 
     const handleShiftClick = (shift, label, icon) => {
+        if (isViewer) return
         if (!shift) return
 
         // Block interaction if absent (except for details viewing, but logic says 'Keine Eintragung möglich')
@@ -411,7 +412,7 @@ export default function DayCard({ dateStr, shifts, userId, onToggleInterest, onT
                     </div>
                 )}
 
-                {isSpecialOptIn && !isAdmin && (
+                {isSpecialOptIn && !isAdmin && !isViewer && (
                     <div className="bg-blue-50 p-4 rounded-xl border border-blue-100 flex justify-between items-center">
                         <span className="font-bold text-blue-900">{amIParticipating ? "Du nimmst teil" : "Möchtest du teilnehmen?"}</span>
                         <button
@@ -654,7 +655,7 @@ export default function DayCard({ dateStr, shifts, userId, onToggleInterest, onT
                     ))}
 
                     {/* Coverage Voting Panels for urgent shifts (Soli system) */}
-                    {USE_COVERAGE_VOTING && ['TD1', 'TD2', 'ND', 'DBD', 'AST'].map(slotCode => {
+                    {USE_COVERAGE_VOTING && !isViewer && ['TD1', 'TD2', 'ND', 'DBD', 'AST'].map(slotCode => {
                         const shift = shifts.find(s => s.type === slotCode)
                         if (!shift) return null
                         const isUrgentShift = !!shift.urgent_since && !shift.assigned_to && (!shift.interests || shift.interests.length === 0)

--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -18,7 +18,7 @@ const SECTIONS = [
 ]
 
 export default function Profile() {
-    const { user, isAdmin } = useAuth()
+    const { user, isAdmin, isViewer } = useAuth()
     const [profile, setProfile] = useState(null)
     const [activeSection, setActiveSection] = useState('settings')
 
@@ -31,7 +31,7 @@ export default function Profile() {
         if (data) setProfile(data)
     }
 
-    const visibleSections = SECTIONS.filter(s => (!s.employeeOnly || !isAdmin) && !s.hidden)
+    const visibleSections = SECTIONS.filter(s => (!s.employeeOnly || (!isAdmin && !isViewer)) && !s.hidden)
 
     if (!profile) {
         return (

--- a/src/components/RosterFeed.jsx
+++ b/src/components/RosterFeed.jsx
@@ -43,7 +43,7 @@ function mergeById(base, additions, matchKeys = ['id']) {
 
 export default function RosterFeed({ onCoverageVoteChanged }) {
 
-    const { user, isAdmin } = useAuth()
+    const { user, isAdmin, isViewer } = useAuth()
     const [shifts, setShifts] = useState([])
     const [allAbsences, setAllAbsences] = useState([])
     const [viewMode, setViewMode] = useState('cards') // 'cards' or 'table'
@@ -447,6 +447,7 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
     }
 
     const toggleInterest = async (shiftId, currentlyInterested, targetUserId = null) => {
+        if (isViewer) return
         const actingUserId = (isAdmin && targetUserId) ? targetUserId : user.id
         const shift = shifts.find(s => s.id === shiftId)
 
@@ -549,7 +550,7 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
     // NOTE: We only write to coverage_votes here. shift_interests is NOT touched until resolve,
     // so the shift does NOT appear "assigned" while voting is in progress.
     const submitCoverageVote = async (shiftId, preference) => {
-        if (!USE_COVERAGE_VOTING || !user) return
+        if (!USE_COVERAGE_VOTING || !user || isViewer) return
 
         if (preference === null) {
             // Remove vote ("Ändern" clicked) - clear preference + responded flag
@@ -684,7 +685,7 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
 
     // Direct takeover: Employee takes an urgent shift without voting (Beta mode)
     const handleDirectTakeover = async (shiftId) => {
-        if (!user) return
+        if (!user || isViewer) return
 
         const shift = shiftsRef.current.find(s => s.id === shiftId)
         if (!shift) {
@@ -1047,7 +1048,7 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
                                         </button>
                                     )}
 
-                                    {!isAdmin && (
+                                    {!isAdmin && !isViewer && (
                                         <button
                                             onClick={() => setIsSickModalOpen(true)}
                                             className="p-1.5 bg-red-50 text-red-600 rounded-full hover:bg-red-100 transition-colors border border-red-100"
@@ -1057,7 +1058,7 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
                                         </button>
                                     )}
 
-                                    {!isAdmin && (
+                                    {!isAdmin && !isViewer && (
                                         <div
                                             className={`p-1.5 rounded-full border transition-colors ${isMonthOpen ? 'bg-green-50 text-green-600 border-green-100' : 'bg-red-50 text-red-600 border-red-100'}`}
                                             title={isMonthOpen ? "Dienstplan offen" : "Dienstplan geschlossen"}
@@ -1142,6 +1143,7 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
                                                         shifts={visibleShiftsByDate[dateStr]}
                                                         userId={user.id}
                                                         isAdmin={isAdmin}
+                                                        isViewer={isViewer}
                                                         onToggleInterest={toggleInterest}
                                                         onToggleFlex={toggleFlex}
                                                         onUpdateShift={async (shiftId, newStart, newEnd, newTitle) => {

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -17,10 +17,10 @@ function Badge({ count, dot = false }) {
     )
 }
 
-export default function Sidebar({ activeTab, onTabChange, isAdmin, badges = {} }) {
+export default function Sidebar({ activeTab, onTabChange, isAdmin, isViewer, badges = {} }) {
     const navItems = [
         { id: 'roster', icon: Calendar, label: 'Dienstplan' },
-        { id: 'times', icon: List, label: 'Zeiten' },
+        ...(!isViewer ? [{ id: 'times', icon: List, label: 'Zeiten' }] : []),
         { id: 'absences', icon: Plane, label: 'Urlaub' },
         ...(isAdmin ? [{ id: 'admin', icon: Shield, label: 'Admin' }] : []),
         { id: 'profile', icon: User, label: 'Profil' }

--- a/src/components/admin/AdminEmployees.jsx
+++ b/src/components/admin/AdminEmployees.jsx
@@ -287,7 +287,8 @@ export default function AdminEmployees() {
     }
 
     const admins = users.filter(u => u.role === 'admin')
-    const employees = users.filter(u => u.role !== 'admin')
+    const viewers = users.filter(u => u.role === 'viewer')
+    const employees = users.filter(u => u.role !== 'admin' && u.role !== 'viewer')
 
     const UserCard = ({ user, isInactive = false }) => (
         <div
@@ -347,6 +348,18 @@ export default function AdminEmployees() {
                     {employees.map(u => <UserCard key={u.id} user={u} />)}
                 </div>
             </div>
+
+            {/* Zuschauer */}
+            {viewers.length > 0 && (
+                <div className="mb-8">
+                    <h3 className="text-xs font-bold text-gray-500 uppercase tracking-wider mb-3 px-2">
+                        Zuschauer
+                    </h3>
+                    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 px-2">
+                        {viewers.map(u => <UserCard key={u.id} user={u} />)}
+                    </div>
+                </div>
+            )}
 
             {/* Inaktive Mitarbeiter */}
             {inactiveUsers.length > 0 && (
@@ -515,6 +528,7 @@ export default function AdminEmployees() {
                                 >
                                     <option value="user">Mitarbeiter</option>
                                     <option value="admin">Administrator</option>
+                                    <option value="viewer">Zuschauer</option>
                                 </select>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- Neue Rolle `viewer` für read-only Zugang zu Dienstplan und Urlaubsplan
- **Frontend**: `isViewer` Flag im AuthContext, Zeiten-Tab ausgeblendet, alle Schreib-Aktionen blockiert (Eintragen, Krankmelden, Tauschen, Urlaub beantragen), Profil zeigt nur Settings
- **RLS**: `is_viewer()` Funktion + 12 Policies auf 6 Tabellen mit `AND NOT is_viewer()` abgesichert (via Supabase Migration)
- **Admin**: Zuschauer-Option im Rollen-Dropdown + eigene Gruppierung in Mitarbeiterliste

## Betroffene Dateien
| Datei | Änderung |
|---|---|
| `AuthContext.jsx` | `isViewer` Flag + Provider |
| `App.jsx` | Tab-Guard, Coverage-Banner, Zeiten-Tab blockiert |
| `BottomNav.jsx` / `Sidebar.jsx` | Zeiten-Tab für Viewer ausgeblendet |
| `RosterFeed.jsx` | Krankmelden/Lock ausgeblendet, Schreib-Funktionen Early return |
| `DayCard.jsx` | Shift-Klick blockiert, Interest/Voting ausgeblendet |
| `AbsencePlanner.jsx` | Tage-Auswahl + Beantragen + Löschen blockiert |
| `Profile.jsx` | Nur Settings-Section sichtbar |
| `AdminEmployees.jsx` | Zuschauer-Option + eigene Gruppe |

## RLS-Migration (bereits auf Supabase angewendet)
- `is_viewer()` Helper-Funktion (analog `is_admin()`)
- 12 Write-Policies auf `absences`, `shift_interests`, `time_entries`, `monthly_reports`, `coverage_votes`, `signatures` blockieren Viewer auf DB-Ebene

## Test plan
- [x] `npm run build` — keine Fehler
- [x] `npm test` — 645 Tests grün
- [x] Manuell: Viewer-Account getestet → nur Dienstplan + Urlaub + Profil Tabs sichtbar
- [x] Manuell: Keine Schreib-Buttons im Dienstplan/Urlaubsplan
- [ ] CI muss grün sein

fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Viewer" role with restricted permissions
  * Viewers can access the roster and profile but cannot interact with shifts or submit absence requests
  * Viewers cannot access the Times tab or participate in coverage voting
  * Updated admin interface to create and manage users with the Viewer role

<!-- end of auto-generated comment: release notes by coderabbit.ai -->