### PR TITLE
fix: Urlaubsansuchen-PDF zeigt Name statt E-Mail für Mitarbeiter

### DIFF
--- a/src/components/AbsencePlanner.jsx
+++ b/src/components/AbsencePlanner.jsx
@@ -324,7 +324,7 @@ export default function AbsencePlanner({ initialDate }) {
                 .eq('id', user.id)
                 .single()
 
-            const employeeName = profile?.full_name || user?.full_name || user?.email || 'Mitarbeiter'
+            const employeeName = profile?.full_name || request.profiles?.full_name || user?.email || 'Mitarbeiter'
             const yearlyEntitlement = profile?.vacation_days_per_year || 25
             const facilityName = profile?.facility || profile?.department || 'Chill Out'
 


### PR DESCRIPTION
## Summary
- Employee-generierte Urlaubsansuchen-PDFs zeigten E-Mail statt Name im Header und Signatur-Box
- Ursache: Fallback `user.full_name` existiert nicht auf dem Supabase Auth-User, dadurch direkt auf `user.email` zurückgefallen
- Fix: Nutzt den bereits geladenen Profile-JOIN (`request.profiles.full_name`) als Fallback vor der E-Mail

## Test plan
- [ ] Als Mitarbeiter einloggen → genehmigten Urlaub → PDF herunterladen → Name statt E-Mail prüfen
- [ ] Als Admin → selben Urlaub in AdminAbsences → PDF herunterladen → Vergleich: beide zeigen gleichen Namen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved name resolution in vacation PDF downloads to ensure accurate employee identification across different data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->