### PR TITLE
fix: initial_balance im Invite-Fallback + DB-Migration

### DIFF
--- a/src/components/admin/AdminEmployees.jsx
+++ b/src/components/admin/AdminEmployees.jsx
@@ -153,6 +153,7 @@ export default function AdminEmployees() {
                     start_date: formData.start_date,
                     vacation_days_per_year: parseFloat(formData.vacation_days_per_year) || 25,
                     role: formData.role,
+                    initial_balance: parseFloat(formData.initial_balance) || 0,
                 }])
                 if (inviteError) {
                     throw new Error(inviteError.message)

--- a/supabase/migrations/20260328100000_invitations_initial_balance.sql
+++ b/supabase/migrations/20260328100000_invitations_initial_balance.sql
@@ -1,0 +1,36 @@
+-- Add initial_balance to invitations table so fallback invite flow preserves hour balances
+ALTER TABLE public.invitations
+ADD COLUMN IF NOT EXISTS initial_balance DECIMAL(10,2) DEFAULT 0;
+
+-- Update handle_new_user() trigger to copy initial_balance from invitation to profile
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+DECLARE
+    invite_record record;
+BEGIN
+    -- Check if email is invited
+    SELECT * INTO invite_record FROM public.invitations WHERE email = NEW.email;
+
+    IF invite_record IS NULL THEN
+        RAISE EXCEPTION 'Email not authorized. Please contact admin.';
+    END IF;
+
+    -- Insert into profiles with data from invitation (including initial_balance)
+    INSERT INTO public.profiles (id, email, full_name, role, weekly_hours, start_date, vacation_days_per_year, initial_balance)
+    VALUES (
+        NEW.id,
+        NEW.email,
+        invite_record.full_name,
+        invite_record.role,
+        invite_record.weekly_hours,
+        invite_record.start_date,
+        invite_record.vacation_days_per_year,
+        COALESCE(invite_record.initial_balance, 0)
+    );
+
+    -- CLEANUP: Delete the invitation so it no longer appears as pending
+    DELETE FROM public.invitations WHERE email = NEW.email;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary\n- Fixes #86: `initial_balance` ging beim Invite-Fallback verloren\n- `ALTER TABLE invitations ADD initial_balance` (Migration bereits auf Supabase angewendet)\n- `handle_new_user()` Trigger kopiert jetzt `initial_balance` in `profiles`\n- Fallback-Insert in `AdminEmployees` mit expliziten Feldern inkl. `initial_balance`\n\n## Test plan\n- [ ] Edge Function deaktivieren, neuen User mit `initial_balance = 5` anlegen\n- [ ] Prüfen: `invitations`-Tabelle enthält `initial_balance = 5`\n- [ ] User registriert sich → `profiles.initial_balance = 5`\n- [ ] Balance-Berechnung zeigt korrekten Übertrag\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invited users can now be assigned an initial account balance at the time of invitation.

* **Bug Fixes**
  * Fixed initial balance information not being retained during admin invitation creation.
  * Improved invitation lifecycle by ensuring invitations are properly finalized after user onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->