### PR TITLE
fix: Edge Function create-user — Einladungs-E-Mails repariert (#104)

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,5 +1,20 @@
+const ALLOWED_ORIGINS = [
+    'https://wobeapp.pages.dev',
+    'https://wobeplaner.pages.dev',
+]
+
+export function getCorsHeaders(req: Request) {
+    const origin = req.headers.get('Origin') ?? ''
+    const allowedOrigin = ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0]
+    return {
+        'Access-Control-Allow-Origin': allowedOrigin,
+        'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+    }
+}
+
+// Static fallback for non-request contexts
 export const corsHeaders = {
-    'Access-Control-Allow-Origin': 'https://wobeplaner.pages.dev',
+    'Access-Control-Allow-Origin': 'https://wobeapp.pages.dev',
     'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 

--- a/supabase/functions/create-user/index.ts
+++ b/supabase/functions/create-user/index.ts
@@ -14,9 +14,11 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
-import { corsHeaders } from '../_shared/cors.ts'
+import { getCorsHeaders } from '../_shared/cors.ts'
 
 serve(async (req) => {
+    const corsHeaders = getCorsHeaders(req)
+
     // Handle CORS preflight
     if (req.method === 'OPTIONS') {
         return new Response('ok', { headers: corsHeaders })
@@ -38,12 +40,18 @@ serve(async (req) => {
             {
                 global: {
                     headers: { Authorization: authHeader }
+                },
+                auth: {
+                    autoRefreshToken: false,
+                    persistSession: false
                 }
             }
         )
 
         // 3. Get the calling user and verify they're an admin
-        const { data: { user: callingUser }, error: userError } = await supabaseUserClient.auth.getUser()
+        // Must pass the JWT explicitly — without it, getUser() checks internal session (empty in edge functions)
+        const jwt = authHeader.replace('Bearer ', '')
+        const { data: { user: callingUser }, error: userError } = await supabaseUserClient.auth.getUser(jwt)
 
         if (userError || !callingUser) {
             throw new Error('Nicht autorisiert: Ungültige Session')
@@ -86,8 +94,26 @@ serve(async (req) => {
             throw new Error('Ein Benutzer mit dieser E-Mail existiert bereits')
         }
 
-        // 7. Create user AND send invite email in ONE step
+        // 7. Pre-populate invitations so the DB trigger (handle_new_user) can find the record
+        // The trigger checks invitations by email before allowing a new auth user to be created
+        const { error: inviteInsertError } = await supabaseAdmin.from('invitations').upsert({
+            email: email,
+            full_name: full_name || '',
+            role: role || 'user',
+            weekly_hours: weekly_hours || 40,
+            start_date: start_date || new Date().toISOString().split('T')[0],
+            vacation_days_per_year: vacation_days_per_year || 25,
+            initial_balance: initial_balance || 0
+        }, { onConflict: 'email' })
+
+        if (inviteInsertError) {
+            console.error('Invitation pre-insert error:', inviteInsertError)
+            throw new Error(`Fehler beim Vorbereiten der Einladung: ${inviteInsertError.message}`)
+        }
+
+        // 8. Create user AND send invite email in ONE step
         // inviteUserByEmail creates the user and sends an email with a magic link
+        // The DB trigger will create the profile and clean up the invitation record
         const { data: inviteData, error: inviteError } = await supabaseAdmin.auth.admin.inviteUserByEmail(email, {
             redirectTo: `${Deno.env.get('SITE_URL') || 'https://wobeplaner.pages.dev'}`,
             data: {
@@ -172,7 +198,7 @@ serve(async (req) => {
             }),
             {
                 headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-                status: 400
+                status: 200
             }
         )
     }


### PR DESCRIPTION
## Summary
- **JWT explizit übergeben** an `auth.getUser(jwt)` — Edge Functions haben keine interne Session
- **CORS dynamisch** via `getCorsHeaders(req)` mit Allowlist für `wobeapp.pages.dev` + `wobeplaner.pages.dev`
- **invitations pre-populate** vor `inviteUserByEmail` — DB-Trigger `handle_new_user` verlangt Eintrag
- **Error-Response Status 200** statt 400 — `supabase.functions.invoke` setzt `response.data = null` bei non-2xx, was den Legacy-Fallback auslöst

## Test plan
- [x] Edge Function v11 deployed und getestet
- [x] Einladungs-E-Mail kommt an (Gmail SMTP)
- [x] Fehlermeldungen werden korrekt im UI angezeigt (kein Legacy-Fallback)

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented dynamic CORS header management supporting multiple allowed application origins with intelligent fallback handling.

* **Improvements**
  * Updated application domain configuration for cross-origin requests.
  * Enhanced user invitation creation flow with improved data validation and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->