### PR TITLE
feat: Anmerkungsspalte in Zeiterfassungs-PDF aufteilen (MA + Admin)

### DIFF
--- a/src/components/AdminTimeTracking.jsx
+++ b/src/components/AdminTimeTracking.jsx
@@ -1112,6 +1112,12 @@ export default function AdminTimeTracking() {
                                     </div>
                                 </div>
                             )}
+                            {/* Show employee note */}
+                            {e.employee_note && (
+                                <div className="mt-2 bg-gray-50 p-2 rounded-lg border border-gray-200">
+                                    <div className="text-xs text-gray-600"><span className="font-bold">MA-Anmerkung:</span> {e.employee_note}</div>
+                                </div>
+                            )}
                         </div>
                     )
                 })}
@@ -1505,6 +1511,13 @@ export default function AdminTimeTracking() {
                                     <span>{calculatedHours.toFixed(2)}h</span>
                                 </div>
                             </div>
+
+                            {editingEntry.employee_note && (
+                                <div>
+                                    <label className="block text-xs font-bold text-gray-500 mb-1">Mitarbeiter Notiz</label>
+                                    <div className="w-full bg-gray-100 border border-gray-200 p-3 rounded-lg text-sm text-gray-600">{editingEntry.employee_note}</div>
+                                </div>
+                            )}
 
                             <div>
                                 <label className="block text-xs font-bold text-gray-500 mb-1">Admin Notiz</label>

--- a/src/components/TimeTracking.jsx
+++ b/src/components/TimeTracking.jsx
@@ -92,7 +92,8 @@ export default function TimeTracking() {
         interruptions: [],
         newIntStart: '',
         newIntEnd: '',
-        newIntNote: ''
+        newIntNote: '',
+        employeeNote: ''
     })
     const [calculatedHours, setCalculatedHours] = useState(0)
 
@@ -121,7 +122,8 @@ export default function TimeTracking() {
                     })),
                     newIntStart: '',
                     newIntEnd: '',
-                    newIntNote: ''
+                    newIntNote: '',
+                    employeeNote: entry.employee_note || ''
                 })
             } else {
                 if (editingItem.itemType === 'shift') {
@@ -131,7 +133,8 @@ export default function TimeTracking() {
                         interruptions: [],
                         newIntStart: '',
                         newIntEnd: '',
-                        newIntNote: ''
+                        newIntNote: '',
+                        employeeNote: ''
                     })
                 } else {
                     // Absence Default: Use weekly_hours / 5 for daily hours
@@ -146,7 +149,8 @@ export default function TimeTracking() {
                         interruptions: [],
                         newIntStart: '',
                         newIntEnd: '',
-                        newIntNote: ''
+                        newIntNote: '',
+                        employeeNote: ''
                     })
                 }
             }
@@ -682,7 +686,8 @@ export default function TimeTracking() {
             interruptions: finalInterruptions,
             calculated_hours: calculatedHours,
             status: 'submitted',
-            original_data: { start: startIso, end: endIso, interruptions: finalInterruptions }
+            original_data: { start: startIso, end: endIso, interruptions: finalInterruptions },
+            employee_note: formData.employeeNote || null
         }
 
         let query = supabase.from('time_entries')
@@ -706,7 +711,7 @@ export default function TimeTracking() {
                 }
                 // Skip the normal query flow
                 setEditingItem(null)
-                setFormData({ actualStart: '', actualEnd: '', interruptions: [] })
+                setFormData({ actualStart: '', actualEnd: '', interruptions: [], employeeNote: '' })
                 setCalculatedHours(null)
                 fetchData(true)
                 return
@@ -1132,6 +1137,11 @@ export default function TimeTracking() {
                                                     </div>
                                                 </div>
                                             )}
+                                            {entry?.employee_note && (
+                                                <div className="mt-2 bg-gray-50 p-2 rounded border border-gray-200">
+                                                    <div className="text-xs text-gray-600"><span className="font-bold">Anmerkung:</span> {entry.employee_note}</div>
+                                                </div>
+                                            )}
                                         </div>
                                     )
                                 })()}
@@ -1385,6 +1395,18 @@ export default function TimeTracking() {
                                         )}
                                     </div>
                                 )}
+                                <div className="mt-4">
+                                    <label className="block text-xs font-bold text-gray-500 uppercase tracking-wider mb-1">Anmerkung</label>
+                                    <textarea
+                                        value={formData.employeeNote}
+                                        onChange={e => setFormData({ ...formData, employeeNote: e.target.value })}
+                                        readOnly={isApproved}
+                                        placeholder="Optionale Notiz zum Eintrag…"
+                                        maxLength={200}
+                                        rows={2}
+                                        className={`w-full border p-3 rounded-xl text-sm transition-all outline-none resize-none ${isApproved ? 'bg-gray-100 border-gray-200 text-gray-500' : 'bg-gray-50 border-gray-200 focus:border-black focus:ring-1 focus:ring-black'}`}
+                                    />
+                                </div>
                                 <div className="bg-blue-50 p-4 rounded-xl border border-blue-100 shadow-sm mt-4">
                                     <div className="flex justify-between items-center text-blue-900 font-bold">
                                         <span className="text-sm uppercase tracking-wider">Berechnet</span>

--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -202,7 +202,9 @@ export const generateTimeReportPDF = (yearMonthStr, user, entries, statusData) =
         x += 22
         doc.text("Stunden", x, y)
         x += 16
-        doc.text("Anm.", x, y)
+        doc.text("MA", x, y)
+        x += 28
+        doc.text("Admin", x, y)
 
         y += 6
 
@@ -247,11 +249,20 @@ export const generateTimeReportPDF = (yearMonthStr, user, entries, statusData) =
                 doc.setFont("helvetica", "bold")
                 doc.text(`${Number(entry.calculated_hours).toFixed(2)}h`, margin + 108, y)
                 doc.setFont("helvetica", "normal")
-                // KRANK in Anmerkungen
-                if (isSickAbs) {
+                // MA-Anmerkung (KRANK flag + employee note)
+                if (isSickAbs || entry.employee_note) {
+                    doc.setFontSize(7)
+                    doc.setTextColor(60, 60, 60)
+                    const maParts = [isSickAbs ? 'KRANK' : '', entry.employee_note?.substring(0, 18) || ''].filter(Boolean).join(' ')
+                    doc.text(maParts, margin + 124, y)
+                    doc.setFontSize(9)
+                    doc.setTextColor(...primaryColor)
+                }
+                // Admin-Anmerkung
+                if (entry.admin_note) {
                     doc.setFontSize(7)
                     doc.setTextColor(150, 100, 0)
-                    doc.text('KRANK', margin + 124, y)
+                    doc.text(entry.admin_note.substring(0, 22), margin + 152, y)
                     doc.setFontSize(9)
                     doc.setTextColor(...primaryColor)
                 }
@@ -355,24 +366,32 @@ export const generateTimeReportPDF = (yearMonthStr, user, entries, statusData) =
                     doc.text(`${entry.calculated_hours.toFixed(2)}h`, margin + 108, y)
                     doc.setFont("helvetica", "normal")
 
-                    // Admin Note column at margin + 124
+                    // MA-Anmerkung (FLEX flag, employee note)
+                    const isFlex = entry.is_flex === true
+                    const maShiftParts = [isFlex ? 'FLEX' : '', entry.employee_note?.substring(0, 18) || ''].filter(Boolean).join(' ')
+                    if (maShiftParts) {
+                        doc.setFontSize(7)
+                        doc.setTextColor(60, 60, 60)
+                        doc.text(maShiftParts, margin + 124, y)
+                        doc.setFontSize(9)
+                        doc.setTextColor(...primaryColor)
+                    }
+
+                    // Admin-Anmerkung at margin + 152
                     if (isCorrection) {
                         doc.setFontSize(7)
                         doc.setTextColor(...correctionColor)
-                        // Show admin_note if available, otherwise just "Korr."
                         let noteText = 'Korr.'
                         if (entry.admin_note) {
-                            // Admin made a correction with note
-                            noteText = 'Admin: ' + entry.admin_note.substring(0, 25)
+                            noteText = entry.admin_note.substring(0, 22)
                         }
-                        doc.text(noteText, margin + 124, y)
+                        doc.text(noteText, margin + 152, y)
                         doc.setFontSize(9)
                         doc.setTextColor(...primaryColor)
                     } else if (entry.admin_note) {
-                        // Admin note without time correction (e.g. interruption edit)
                         doc.setFontSize(7)
-                        doc.setTextColor(150, 100, 0) // Orange for admin notes
-                        doc.text('Admin: ' + entry.admin_note.substring(0, 25), margin + 124, y)
+                        doc.setTextColor(150, 100, 0)
+                        doc.text(entry.admin_note.substring(0, 22), margin + 152, y)
                         doc.setFontSize(9)
                         doc.setTextColor(...primaryColor)
                     }

--- a/src/utils/timeReportPdfGenerator.js
+++ b/src/utils/timeReportPdfGenerator.js
@@ -119,7 +119,7 @@ const buildLines = (segments) => {
 }
 
 /** Build a single PDF row for a night-shift segment line, with optional correction comparison */
-const buildSegmentRow = (line, lineIdx, origLines, shiftType, isFlex, correction, dayStr, isSickEntry = false) => {
+const buildSegmentRow = (line, lineIdx, origLines, shiftType, isFlex, correction, dayStr, isSickEntry = false, employeeNote = '') => {
     const intNote = line.note || ''
     let intCorrection = null
 
@@ -144,8 +144,11 @@ const buildSegmentRow = (line, lineIdx, origLines, shiftType, isFlex, correction
     }
 
     const isFirst = lineIdx === 0
-    const anm = isFirst
-        ? [isSickEntry ? 'KRANK' : '', isFlex ? 'FLEX' : '', correction?.adminNote?.substring(0, 24) || ''].filter(Boolean).join(' ')
+    const anmMA = isFirst
+        ? [isSickEntry ? 'KRANK' : '', isFlex ? 'FLEX' : '', employeeNote?.substring(0, 20) || ''].filter(Boolean).join(' ')
+        : ''
+    const anmAdmin = isFirst
+        ? (correction?.adminNote?.substring(0, 22) || '')
         : ''
 
     return {
@@ -157,7 +160,8 @@ const buildSegmentRow = (line, lineIdx, origLines, shiftType, isFlex, correction
         bzVon:      line.standby ? timeToDecimal(line.standby.start.toISOString()) : '',
         bzBis:      line.standby ? timeToDecimal(line.standby.end.toISOString(), true) : '',
         correction: isFirst ? correction : null,
-        anm,
+        anmMA,
+        anmAdmin,
         intNote,
         intCorrection,
     }
@@ -205,7 +209,7 @@ const buildPdfRows = (entries, correctionMap) => {
 
             const isSickND = entry.absences?.type === 'Krank' || entry.absences?.type === 'Krankenstand'
             lines.forEach((line, lineIdx) => {
-                rows.push(buildSegmentRow(line, lineIdx, origLines, shiftType, isFlex, correction, dayStr, isSickND))
+                rows.push(buildSegmentRow(line, lineIdx, origLines, shiftType, isFlex, correction, dayStr, isSickND, entry.employee_note))
             })
         } else {
             // Regular entry (TD1, TD2, TEAM, Krank, Urlaub, etc.)
@@ -219,7 +223,8 @@ const buildPdfRows = (entries, correctionMap) => {
                 bzVon:     '',
                 bzBis:     '',
                 correction: correction || null,
-                anm:       [isSickEntry ? 'KRANK' : '', isFlex ? 'FLEX' : '', correction?.adminNote?.substring(0, 24) || ''].filter(Boolean).join(' '),
+                anmMA:     [isSickEntry ? 'KRANK' : '', isFlex ? 'FLEX' : '', entry.employee_note?.substring(0, 20) || ''].filter(Boolean).join(' '),
+                anmAdmin:  correction?.adminNote?.substring(0, 22) || '',
             })
         }
     })
@@ -319,13 +324,14 @@ export const generateTimeReportPDF = ({
     // =========================================================================
     const colX = {
         datum: margin,
-        tag: margin + 18,
-        dienst: margin + 32,
-        azVon: margin + 57,
-        azBis: margin + 77,
-        bzVon: margin + 97,
-        bzBis: margin + 117,
-        anm: margin + 137
+        tag: margin + 14,
+        dienst: margin + 26,
+        azVon: margin + 48,
+        azBis: margin + 68,
+        bzVon: margin + 88,
+        bzBis: margin + 108,
+        anmMA: margin + 128,
+        anmAdmin: margin + 156,
     }
 
     const rowHeight = 7
@@ -337,6 +343,9 @@ export const generateTimeReportPDF = ({
         dienst: (colX.dienst + colX.azVon) / 2,
     }
 
+    // Anmerkungen group header center
+    const anmGroupCenter = (colX.anmMA + pageWidth - margin) / 2
+
     const drawTableHeader = () => {
         // Header row 1: Group titles
         doc.setFont('helvetica', 'bold')
@@ -345,6 +354,7 @@ export const generateTimeReportPDF = ({
 
         doc.text('Arbeitszeit', colX.azVon + 10, yPos, { align: 'center' })
         doc.text('Bereitschaftszeit', colX.bzVon + 10, yPos, { align: 'center' })
+        doc.text('Anmerkungen', anmGroupCenter, yPos, { align: 'center' })
 
         yPos += 4
 
@@ -357,7 +367,8 @@ export const generateTimeReportPDF = ({
         doc.text('Bis', colX.azBis, yPos)
         doc.text('Von', colX.bzVon, yPos)
         doc.text('Bis', colX.bzBis, yPos)
-        doc.text('Anm.', colX.anm, yPos)
+        doc.text('MA', colX.anmMA, yPos)
+        doc.text('Admin', colX.anmAdmin, yPos)
 
         yPos += 3
         doc.setDrawColor(226, 232, 240)
@@ -479,17 +490,26 @@ export const generateTimeReportPDF = ({
         doc.text(row.bzVon, colX.bzVon, textY)
         doc.text(row.bzBis, colX.bzBis, textY)
 
-        // Admin note (only on first row of entry) or interruption note
-        if (row.anm) {
-            doc.setFontSize(8)
-            doc.setTextColor(150, 100, 0)
-            doc.text(row.anm, colX.anm, textY)
+        // MA-Anmerkung (KRANK/FLEX flags, employee note, interruption notes)
+        if (row.anmMA) {
+            doc.setFontSize(7)
+            doc.setTextColor(60, 60, 60)
+            doc.text(row.anmMA.substring(0, 20), colX.anmMA, textY)
             doc.setTextColor(0, 0, 0)
             doc.setFontSize(9)
         } else if (row.intNote) {
             doc.setFontSize(7)
             doc.setTextColor(80, 80, 80)
-            doc.text(row.intNote.substring(0, 24), colX.anm, textY)
+            doc.text(row.intNote.substring(0, 20), colX.anmMA, textY)
+            doc.setTextColor(0, 0, 0)
+            doc.setFontSize(9)
+        }
+
+        // Admin-Anmerkung
+        if (row.anmAdmin) {
+            doc.setFontSize(7)
+            doc.setTextColor(150, 100, 0)
+            doc.text(row.anmAdmin.substring(0, 22), colX.anmAdmin, textY)
             doc.setTextColor(0, 0, 0)
             doc.setFontSize(9)
         }

--- a/supabase/migrations/20260401100000_add_employee_note.sql
+++ b/supabase/migrations/20260401100000_add_employee_note.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.time_entries ADD COLUMN IF NOT EXISTS employee_note text;


### PR DESCRIPTION
## Summary\n\n- **DB-Migration**: Neues `employee_note` text-Feld auf `time_entries`\n- **TimeTracking**: Textarea für Mitarbeiter-Anmerkung + Anzeige in Listenansicht\n- **AdminTimeTracking**: MA-Anmerkung readonly im Edit-Modal + in Listenansicht sichtbar\n- **timeReportPdfGenerator**: `Anm.`-Spalte aufgeteilt in `MA` (28mm) + `Admin` (34mm) durch Komprimierung von Datum/Tag/Dienst-Spalten\n- **pdfGenerator**: Legacy-PDF gleiche Aufteilung (`MA` + `Admin`)\n\nFixes #117\n\n## Test plan\n\n- [ ] Zeiterfassung: Eintrag bearbeiten → Anmerkung-Textarea sichtbar, Eingabe möglich\n- [ ] Zeiterfassung: Anmerkung wird in der Listenansicht direkt angezeigt (ohne Klick)\n- [ ] Admin-Zeiterfassung: MA-Anmerkung readonly im Edit-Modal sichtbar\n- [ ] Admin-Zeiterfassung: MA-Anmerkung in Listenansicht sichtbar\n- [ ] PDF (Zeitbericht): Zwei getrennte Spalten MA + Admin im Header und Datenzeilen\n- [ ] PDF (Legacy): Zwei getrennte Spalten MA + Admin\n- [ ] Approved Einträge: Anmerkung-Textarea ist readonly\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added employee notes field to time entries, allowing users to add and edit notes for individual shifts and absences.
  * Employee notes now display on time entry cards and are editable within entry modals.
  * PDF reports split annotation columns into "MA" (employee notes) and "Admin" sections for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->