### PR TITLE
fix: Stundenkonto Übertrag in Zeiterfassung zeigt 0h

### DIFF
--- a/src/components/TimeTracking.jsx
+++ b/src/components/TimeTracking.jsx
@@ -216,7 +216,7 @@ export default function TimeTracking() {
         if (!currentProfile) {
             const { data: profile } = await supabase
                 .from('profiles')
-                .select('weekly_hours, start_date')
+                .select('weekly_hours, start_date, initial_balance')
                 .eq('id', user.id)
                 .single()
             if (profile) {


### PR DESCRIPTION
Fixes fehlenden Übertrag in der Mitarbeiter-Zeiterfassung. Die Profile-Query hat initial_balance nicht geladen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced time tracking data retrieval to include additional balance information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->