### PR TITLE
fix: Urlaubs-PDF Feiertage + Saldo + Stundenverlauf korrigieren (#157)

### DIFF
--- a/src/components/AbsencePlanner.jsx
+++ b/src/components/AbsencePlanner.jsx
@@ -337,8 +337,6 @@ export default function AbsencePlanner({ initialDate }) {
     const handleDownloadVacationPDF = async (request, _days) => {
         try {
             const { generateVacationRequestPDF } = await import('../utils/vacationPdfGenerator')
-            const { differenceInBusinessDays } = await import('date-fns')
-
             // Fetch signature
             const { data: signature } = await supabase
                 .from('signatures')
@@ -358,35 +356,19 @@ export default function AbsencePlanner({ initialDate }) {
                 if (approver) approverName = approver.full_name || approver.email
             }
 
-            // Fetch full profile for name and vacation entitlement
+            // Fetch profile for name and facility
             const { data: profile } = await supabase
                 .from('profiles')
-                .select('full_name, email, vacation_days_per_year, facility, department')
+                .select('full_name, email, facility, department')
                 .eq('id', user.id)
                 .single()
 
             const employeeName = profile?.full_name || request.profiles?.full_name || user?.email || 'Mitarbeiter'
-            const yearlyEntitlement = profile?.vacation_days_per_year || 25
             const facilityName = profile?.facility || profile?.department || 'Chill Out'
 
-            // Calculate vacation balance
-            const year = new Date(request.start_date).getFullYear()
-            const { data: allVacations } = await supabase
-                .from('absences')
-                .select('start_date, end_date')
-                .eq('user_id', user.id)
-                .eq('status', 'genehmigt')
-                .eq('type', 'Urlaub')
-                .gte('start_date', `${year}-01-01`)
-                .lte('start_date', `${year}-12-31`)
-
-            let daysUsedTotal = 0
-            if (allVacations) {
-                allVacations.forEach(v => {
-                    daysUsedTotal += differenceInBusinessDays(new Date(v.end_date), new Date(v.start_date)) + 1
-                })
-            }
-            const remaining = yearlyEntitlement - daysUsedTotal
+            // Use already-loaded myStats for vacation account (avoids re-query issues)
+            const yearlyEntitlement = myStats?.entitlement || 25
+            const remaining = myStats?.remaining ?? 0
 
             generateVacationRequestPDF({
                 request,

--- a/src/components/ProfileStats.jsx
+++ b/src/components/ProfileStats.jsx
@@ -566,25 +566,12 @@ export default function ProfileStats() {
     }
 
     // Chart calculations
-    const maxAbsDiff = useMemo(() => {
+    const maxAbsTotal = useMemo(() => {
         if (monthlyData.length === 0) return 1
-        return Math.max(...monthlyData.map(m => Math.abs(m.diff)), 1)
+        return Math.max(...monthlyData.map(m => Math.abs(m.total)), 1)
     }, [monthlyData])
 
-    const cumulativeData = useMemo(() => {
-        let cumulative = 0
-        return monthlyData.map(m => {
-            cumulative += m.diff
-            return { ...m, cumulative: Math.round(cumulative * 100) / 100 }
-        })
-    }, [monthlyData])
-
-    const maxAbsCumulative = useMemo(() => {
-        if (cumulativeData.length === 0) return 1
-        return Math.max(...cumulativeData.map(m => Math.abs(m.cumulative)), 1)
-    }, [cumulativeData])
-
-    const currentCumulative = cumulativeData.at(-1)?.cumulative ?? 0
+    const currentCumulative = monthlyData.at(-1)?.total ?? 0
 
     const flexMonths = useMemo(() => {
         return monthlyData.map(m => ({
@@ -966,7 +953,7 @@ export default function ProfileStats() {
                             {currentCumulative > 0 ? '+' : ''}{currentCumulative}h
                         </span>
                     </div>
-                    <p className="text-xs text-gray-400 mb-4">Monatlicher Saldo der letzten 12 Monate</p>
+                    <p className="text-xs text-gray-400 mb-4">Gesamtsaldo der letzten 12 Monate</p>
 
                     {/* Balkendiagramm */}
                     <div className="flex items-stretch gap-1 h-24 relative">
@@ -974,8 +961,8 @@ export default function ProfileStats() {
                         <div className="absolute inset-x-0 top-1/2 border-t border-dashed border-gray-200 pointer-events-none" />
 
                         {monthlyData.map((m) => {
-                            const heightPct = Math.abs(m.diff) / maxAbsDiff * 45
-                            const isPositive = m.diff >= 0
+                            const heightPct = Math.abs(m.total) / maxAbsTotal * 45
+                            const isPositive = m.total >= 0
                             return (
                                 <div key={m.month} className="flex-1 flex flex-col h-full">
                                     {/* obere Hälfte */}
@@ -986,7 +973,7 @@ export default function ProfileStats() {
                                                 style={{ height: `${heightPct}%` }}
                                             >
                                                 <span className="absolute -top-4 left-1/2 -translate-x-1/2 text-[9px] font-bold text-teal-700 whitespace-nowrap">
-                                                    +{m.diff}
+                                                    +{m.total}
                                                 </span>
                                             </div>
                                         )}
@@ -999,7 +986,7 @@ export default function ProfileStats() {
                                                 style={{ height: `${heightPct}%` }}
                                             >
                                                 <span className="absolute top-full mt-0.5 left-1/2 -translate-x-1/2 text-[9px] font-bold text-red-600 whitespace-nowrap">
-                                                    {m.diff}
+                                                    {m.total}
                                                 </span>
                                             </div>
                                         )}

--- a/src/components/admin/AdminAbsences.jsx
+++ b/src/components/admin/AdminAbsences.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Calendar, CheckCircle, XCircle, Download, Trash2 } from 'lucide-react'
-import { format, differenceInBusinessDays } from 'date-fns'
+import { format, eachDayOfInterval, isWeekend } from 'date-fns'
+import { getHolidays, isHoliday } from '../../utils/holidays'
 import { supabase } from '../../supabase'
 import { logAdminAction } from '../../utils/adminAudit'
 import { generateVacationRequestPDF } from '../../utils/vacationPdfGenerator'
@@ -21,9 +22,9 @@ export default function AdminAbsences({ onNavigateToCalendar }) {
     const [_downloadedIds, setDownloadedIds] = useState(new Set())
 
     const fetchRequests = async () => {
-        const { data: pending } = await supabase.from('absences').select('*, profiles!user_id(full_name, email)').eq('status', 'beantragt').neq('type', 'Krank').order('start_date')
+        const { data: pending } = await supabase.from('absences').select('*, profiles!user_id(full_name, email, vacation_days_per_year)').eq('status', 'beantragt').neq('type', 'Krank').order('start_date')
         setRequests(pending || [])
-        const { data: processed } = await supabase.from('absences').select('*, profiles!user_id(full_name, email)').in('status', ['genehmigt', 'abgelehnt', 'storniert']).neq('type', 'Krank').order('start_date', { ascending: false }).limit(50)
+        const { data: processed } = await supabase.from('absences').select('*, profiles!user_id(full_name, email, vacation_days_per_year)').in('status', ['genehmigt', 'abgelehnt', 'storniert']).neq('type', 'Krank').order('start_date', { ascending: false }).limit(50)
         setArchive(processed || [])
     }
 
@@ -154,8 +155,11 @@ export default function AdminAbsences({ onNavigateToCalendar }) {
 
             let daysUsedTotal = 0
             if (allVacations) {
+                const holidays = getHolidays(year)
                 allVacations.forEach(v => {
-                    daysUsedTotal += differenceInBusinessDays(new Date(v.end_date), new Date(v.start_date)) + 1
+                    daysUsedTotal += eachDayOfInterval({ start: new Date(v.start_date), end: new Date(v.end_date) })
+                        .filter(d => !isWeekend(d) && !isHoliday(d, holidays))
+                        .length
                 })
             }
             const remaining = yearlyEntitlement - daysUsedTotal

--- a/src/utils/vacationPdfGenerator.js
+++ b/src/utils/vacationPdfGenerator.js
@@ -14,8 +14,28 @@
  */
 
 import { jsPDF } from 'jspdf'
-import { format, differenceInBusinessDays, isSameDay } from 'date-fns'
+import { format, isSameDay } from 'date-fns'
 import { getHolidays } from './holidays'
+
+/**
+ * Count workdays (Mon-Fri, excluding Austrian holidays) in a date range, inclusive.
+ */
+const countWorkdays = (start, end) => {
+    const holidays = [
+        ...getHolidays(start.getFullYear()),
+        ...getHolidays(end.getFullYear()),
+    ]
+    let count = 0
+    let current = new Date(start)
+    while (current <= end) {
+        const day = current.getDay()
+        if (day !== 0 && day !== 6 && !holidays.some(h => isSameDay(h.date, current))) {
+            count++
+        }
+        current.setDate(current.getDate() + 1)
+    }
+    return count
+}
 
 /**
  * Calculate the first working day after a given date
@@ -64,7 +84,7 @@ export const generateVacationRequestPDF = ({
     const startDate = new Date(request.start_date)
     const endDate = new Date(request.end_date)
     const returnDate = getFirstWorkingDayAfter(endDate)
-    const durationDays = differenceInBusinessDays(endDate, startDate) + 1
+    const durationDays = countWorkdays(startDate, endDate)
 
     const margin = 20
     const pageWidth = doc.internal.pageSize.getWidth()
@@ -103,7 +123,7 @@ export const generateVacationRequestPDF = ({
     doc.setFontSize(18)
     doc.setFont(undefined, 'bold')
     doc.setTextColor(15, 23, 42)
-    doc.text('URLAUBSANSUCHEN / MELDUNG', pageWidth / 2, yPos, { align: 'center' })
+    doc.text('URLAUBSANSUCHEN', pageWidth / 2, yPos, { align: 'center' })
 
     // =========================================================================
     // STATUS BADGE (centered)
@@ -195,8 +215,9 @@ export const generateVacationRequestPDF = ({
     const rightColX = margin + contentWidth - 35
     doc.setFontSize(12)
 
-    // Balance before
-    const balanceOld = (vacationAccount?.remaining || 0) + durationDays
+    // Balance before this vacation
+    const remaining = vacationAccount?.remaining ?? 0
+    const balanceOld = remaining + durationDays
     doc.setTextColor(100, 116, 139)
     doc.setFont(undefined, 'normal')
     doc.text('offener Urlaubsanspruch:', margin + 5, calcY)
@@ -222,7 +243,7 @@ export const generateVacationRequestPDF = ({
     doc.setFont(undefined, 'bold')
     doc.text('verbleibender Rest:', margin + 5, calcY)
     doc.setTextColor(21, 128, 61) // green-700
-    doc.text(`${vacationAccount?.remaining || 0} Arbeitstage`, rightColX, calcY, { align: 'right' })
+    doc.text(`${remaining} Arbeitstage`, rightColX, calcY, { align: 'right' })
 
     // =========================================================================
     // SIGNATURE BOX (same style as Arbeitszeitaufzeichnung)


### PR DESCRIPTION
## Summary
- **Urlaubs-PDF**: `differenceInBusinessDays` durch feiertags-bewusste Berechnung ersetzt (Ostermontag wurde als Arbeitstag gezählt → 6 statt 5 Tage)
- **Urlaubs-PDF Saldo**: Urlaubsanspruch aus bereits geladenem `myStats` statt fehlerhafter Re-Query — PDF zeigte 25 statt 31 Tage
- **AdminAbsences**: `vacation_days_per_year` in Profiles-Join ergänzt
- **Stundenverlauf**: Balken zeigen jetzt Gesamtsaldo (`m.total`) statt Monatsdifferenz (`m.diff`), Header nutzt korrekten Wert inkl. Übertrag
- **PDF-Titel**: "URLAUBSANSUCHEN / MELDUNG" → "URLAUBSANSUCHEN"

Fixes #157

## Test plan
- [ ] Urlaubs-PDF als Mitarbeiter downloaden → Tage, Anspruch und Rest müssen mit UI übereinstimmen
- [ ] Urlaub über Feiertag prüfen → Feiertag darf nicht als Arbeitstag zählen
- [ ] Admin-PDF-Download testen → gleiche korrekte Werte
- [ ] Stundenverlauf im Profil → Balken-Wert muss mit Stundenkonto übereinstimmen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Vacation day calculations now properly exclude weekends and Austrian holidays for accurate balance reporting.

* **Improvements**
  * Updated monthly balance chart to display cumulative totals instead of monthly differences.
  * Simplified vacation request PDF title and balance display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->