### PR TITLE
fix: Abwesenheits-Warnung als AlertModal statt native alert() (#159)

### DIFF
--- a/src/components/DayCard.jsx
+++ b/src/components/DayCard.jsx
@@ -3,6 +3,7 @@ import { format, isValid } from 'date-fns'
 import { de } from 'date-fns/locale'
 import { Moon, Sun, CalendarOff, Users, Clock, Coffee, Compass, Thermometer, Plus, BookOpen, GraduationCap, MessageCircle, MoreHorizontal, EyeOff } from 'lucide-react'
 import ActionSheet from './ActionSheet'
+import AlertModal from './AlertModal'
 import CoverageVotingPanel from './CoverageVotingPanel'
 import { calculateWorkHours } from '../utils/timeCalculations'
 import { PRIVATE_SHIFT_TYPES } from '../contexts/ShiftTemplateContext'
@@ -40,6 +41,7 @@ export default function DayCard({ dateStr, shifts, userId, onToggleInterest, onT
     const [editStart, setEditStart] = useState('')
     const [editEnd, setEditEnd] = useState('')
     const [editTitle, setEditTitle] = useState('')
+    const [absenceAlert, setAbsenceAlert] = useState(null)
 
     useEffect(() => {
         if (selectedShift) {
@@ -122,8 +124,12 @@ export default function DayCard({ dateStr, shifts, userId, onToggleInterest, onT
             // Allow viewing Team/Training details even if absent?
             const specialTypes = ['TEAM', 'FORTBILDUNG', 'EINSCHULUNG', 'MITARBEITERGESPRAECH', 'SONSTIGES', 'SUPERVISION']
             if (!specialTypes.includes(shift.type)) {
-                const msg = absenceReason.type && absenceReason.type.toLowerCase() === 'krank' ? 'Du bist krank gemeldet.' : 'Du bist im Urlaub.'
-                alert(msg + ' Keine Eintragung möglich.')
+                const isSickAbsence = absenceReason.type && absenceReason.type.toLowerCase() === 'krank'
+                setAbsenceAlert({
+                    title: isSickAbsence ? 'Krank gemeldet' : 'Im Urlaub',
+                    message: (isSickAbsence ? 'Du bist krank gemeldet.' : 'Du bist im Urlaub.') + ' Keine Eintragung möglich.',
+                    type: 'error'
+                })
                 return
             }
         }
@@ -767,6 +773,13 @@ export default function DayCard({ dateStr, shifts, userId, onToggleInterest, onT
             >
                 {renderSheetContent()}
             </ActionSheet>
+            <AlertModal
+                isOpen={!!absenceAlert}
+                onClose={() => setAbsenceAlert(null)}
+                title={absenceAlert?.title}
+                message={absenceAlert?.message}
+                type={absenceAlert?.type}
+            />
         </>
     )
 }


### PR DESCRIPTION
## Summary\n- Native `alert()` in DayCard bei Diensteintragung an Urlaubs-/Krankentagen durch `AlertModal` ersetzt\n- Zeigt jetzt ein konsistentes Modal mit passendem Titel ("Im Urlaub" / "Krank gemeldet") und rotem Error-Icon\n\nFixes #159\n\n## Test plan\n- [ ] Als Mitarbeiter mit genehmigtem Urlaub auf einen regulären Dienst klicken → AlertModal erscheint\n- [ ] Als Mitarbeiter mit Krankmeldung auf einen regulären Dienst klicken → AlertModal mit "Krank gemeldet" erscheint\n- [ ] Spezial-Events (Team, Fortbildung etc.) bleiben weiterhin klickbar trotz Abwesenheit\n\n🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shift registration blocking notifications have been redesigned. When an approved absence prevents shift registration, users now receive a modal dialog displaying the absence details instead of a browser popup alert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->