### PR TITLE
feat: Kalender-Abo via iCal-Subscription-URL (#163)

### DIFF
--- a/src/components/CalendarSync.jsx
+++ b/src/components/CalendarSync.jsx
@@ -1,0 +1,181 @@
+import { useState, useEffect } from 'react'
+import { supabase } from '../supabase'
+import { Link, Copy, Check, Trash2, RefreshCw, Smartphone } from 'lucide-react'
+import useModal from '../hooks/useModal'
+
+export default function CalendarSync({ userId }) {
+    const { showAlert, showConfirm, modalElement } = useModal()
+    const [token, setToken] = useState(null)
+    const [loading, setLoading] = useState(true)
+    const [creating, setCreating] = useState(false)
+    const [copied, setCopied] = useState(null) // 'https' | 'webcal' | null
+
+    useEffect(() => {
+        loadToken()
+    }, [userId])
+
+    const loadToken = async () => {
+        setLoading(true)
+        const { data } = await supabase
+            .from('calendar_tokens')
+            .select('token, created_at')
+            .eq('user_id', userId)
+            .eq('is_active', true)
+            .maybeSingle()
+        setToken(data?.token || null)
+        setLoading(false)
+    }
+
+    const createToken = async () => {
+        setCreating(true)
+        // Deactivate any existing token
+        await supabase
+            .from('calendar_tokens')
+            .update({ is_active: false })
+            .eq('user_id', userId)
+            .eq('is_active', true)
+
+        const { data, error } = await supabase
+            .from('calendar_tokens')
+            .insert({ user_id: userId })
+            .select('token')
+            .single()
+
+        setCreating(false)
+        if (error) {
+            showAlert({ title: 'Fehler', message: 'Kalender-Link konnte nicht erstellt werden.', type: 'error' })
+            return
+        }
+        setToken(data.token)
+    }
+
+    const revokeToken = () => {
+        showConfirm({
+            title: 'Link widerrufen',
+            message: 'Der aktuelle Kalender-Link wird ungültig. Bereits abonnierte Kalender werden nicht mehr aktualisiert. Du kannst jederzeit einen neuen Link erstellen.',
+            confirmText: 'Widerrufen',
+            isDestructive: true,
+            onConfirm: async () => {
+                await supabase
+                    .from('calendar_tokens')
+                    .update({ is_active: false })
+                    .eq('user_id', userId)
+                    .eq('is_active', true)
+                setToken(null)
+            }
+        })
+    }
+
+    const getHttpsUrl = () => {
+        const base = import.meta.env.VITE_SUPABASE_URL
+        return `${base}/functions/v1/calendar-feed?token=${token}`
+    }
+
+    const getWebcalUrl = () => getHttpsUrl().replace('https://', 'webcal://')
+
+    const copyToClipboard = async (type) => {
+        const url = type === 'webcal' ? getWebcalUrl() : getHttpsUrl()
+        try {
+            await navigator.clipboard.writeText(url)
+            setCopied(type)
+            setTimeout(() => setCopied(null), 2000)
+        } catch {
+            showAlert({ title: 'Fehler', message: 'Link konnte nicht kopiert werden.', type: 'error' })
+        }
+    }
+
+    if (loading) {
+        return <div className="py-4 text-center text-sm text-gray-400">Laden...</div>
+    }
+
+    if (!token) {
+        return (
+            <>
+                <div className="space-y-3">
+                    <p className="text-sm text-gray-500">
+                        Abonniere deine Dienste in Google Calendar, Apple Kalender oder Outlook. Der Kalender aktualisiert sich automatisch.
+                    </p>
+                    <button
+                        onClick={createToken}
+                        disabled={creating}
+                        className="w-full py-3 bg-teal-500 text-white rounded-xl font-bold hover:bg-teal-600 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+                    >
+                        <Link size={18} />
+                        {creating ? 'Wird erstellt...' : 'Abo-Link erstellen'}
+                    </button>
+                </div>
+                {modalElement}
+            </>
+        )
+    }
+
+    return (
+        <>
+            <div className="space-y-3">
+                <p className="text-xs text-green-600 font-medium bg-green-50 px-2 py-1 rounded inline-block">
+                    Kalender-Abo aktiv
+                </p>
+
+                <p className="text-sm text-gray-500">
+                    Kopiere den Link und füge ihn als Kalender-Abo hinzu.
+                </p>
+
+                {/* HTTPS URL - for Google Calendar */}
+                <button
+                    onClick={() => copyToClipboard('https')}
+                    className="w-full flex items-center gap-3 p-3 rounded-xl border border-gray-200 hover:border-teal-300 hover:bg-teal-50/50 transition-colors text-left"
+                >
+                    <div className="p-2 bg-blue-50 rounded-lg text-blue-600 shrink-0">
+                        <Copy size={16} />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium text-gray-900">Link kopieren</div>
+                        <div className="text-xs text-gray-400 truncate">{getHttpsUrl()}</div>
+                    </div>
+                    {copied === 'https' && <Check size={18} className="text-green-500 shrink-0" />}
+                </button>
+
+                {/* webcal:// URL - for Apple Calendar */}
+                <button
+                    onClick={() => copyToClipboard('webcal')}
+                    className="w-full flex items-center gap-3 p-3 rounded-xl border border-gray-200 hover:border-teal-300 hover:bg-teal-50/50 transition-colors text-left"
+                >
+                    <div className="p-2 bg-purple-50 rounded-lg text-purple-600 shrink-0">
+                        <Smartphone size={16} />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium text-gray-900">Apple Kalender (webcal://)</div>
+                        <div className="text-xs text-gray-400">Für iPhone, iPad & Mac</div>
+                    </div>
+                    {copied === 'webcal' && <Check size={18} className="text-green-500 shrink-0" />}
+                </button>
+
+                {/* Actions */}
+                <div className="flex gap-2 pt-1">
+                    <button
+                        onClick={() => { revokeToken() }}
+                        className="flex-1 py-2.5 text-sm text-red-500 bg-red-50 rounded-xl font-medium hover:bg-red-100 transition-colors flex items-center justify-center gap-1.5"
+                    >
+                        <Trash2 size={14} />
+                        Widerrufen
+                    </button>
+                    <button
+                        onClick={async () => {
+                            await supabase
+                                .from('calendar_tokens')
+                                .update({ is_active: false })
+                                .eq('user_id', userId)
+                                .eq('is_active', true)
+                            await createToken()
+                        }}
+                        className="flex-1 py-2.5 text-sm text-gray-600 bg-gray-50 rounded-xl font-medium hover:bg-gray-100 transition-colors flex items-center justify-center gap-1.5"
+                    >
+                        <RefreshCw size={14} />
+                        Neuer Link
+                    </button>
+                </div>
+            </div>
+            {modalElement}
+        </>
+    )
+}

--- a/src/components/RosterFeed.jsx
+++ b/src/components/RosterFeed.jsx
@@ -13,7 +13,7 @@ import SickReportModal from './SickReportModal'
 import ActionSheet from './ActionSheet'
 import MonthSettingsModal from './MonthSettingsModal'
 import MyShiftsView from './MyShiftsView'
-import { LayoutList, Table as TableIcon, ChevronLeft, ChevronRight, Lock, Unlock, ChevronDown, ChevronUp, Thermometer, FileText, Settings, Calendar, User } from 'lucide-react'
+import { LayoutList, Table as TableIcon, ChevronLeft, ChevronRight, Lock, Unlock, ChevronDown, ChevronUp, Thermometer, FileText, Settings, Calendar, User, Download } from 'lucide-react'
 import { format, addMonths, subMonths, startOfMonth, endOfMonth, getYear, getMonth, subDays, isSameMonth, isValid } from 'date-fns'
 import { de } from 'date-fns/locale'
 import { useHolidays } from '../hooks/useHolidays'
@@ -23,6 +23,7 @@ import { calculateWorkHours } from '../utils/timeCalculations'
 import { useShiftTemplates } from '../contexts/ShiftTemplateContext'
 import { getHolidays } from '../utils/holidays'
 import PullToRefresh from './PullToRefresh'
+import CalendarSync from './CalendarSync'
 import { downloadICalFile } from '../utils/calendarExport'
 import { calculateAllFairnessIndices } from '../utils/fairnessIndex'
 import { logAdminAction, fetchBeforeState } from '../utils/adminAudit'
@@ -62,7 +63,7 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
     const [isLogModalOpen, setIsLogModalOpen] = useState(false)
     const [confirmConfig, setConfirmConfig] = useState({ isOpen: false, title: '', message: '', onConfirm: () => { } })
     const [alertConfig, setAlertConfig] = useState({ isOpen: false, title: '', message: '', type: 'info' })
-    const [calendarExportConfirmOpen, setCalendarExportConfirmOpen] = useState(false)
+    const [calendarMenuOpen, setCalendarMenuOpen] = useState(false)
     const [isStatusInfoOpen, setIsStatusInfoOpen] = useState(false)
 
     const [myProfile, setMyProfile] = useState(null)
@@ -905,8 +906,6 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
     }
 
     // Handler for calendar export
-    const handleCalendarExportClick = () => setCalendarExportConfirmOpen(true)
-
     const handleCalendarExport = () => {
         // Get all shifts where user is assigned or has interest (for current month view)
         const myShiftsForMonth = shifts.filter(shift => {
@@ -1046,9 +1045,9 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
                                 <div className="flex gap-1.5 items-center">
                                     {!isAdmin && !isViewer && (
                                         <button
-                                            onClick={handleCalendarExportClick}
+                                            onClick={() => setCalendarMenuOpen(true)}
                                             className="p-1.5 bg-blue-50 text-blue-600 rounded-full hover:bg-blue-100 transition-colors border border-blue-100"
-                                            title="Dienste in Kalender exportieren"
+                                            title="Kalender"
                                         >
                                             <Calendar size={18} />
                                         </button>
@@ -1309,16 +1308,30 @@ export default function RosterFeed({ onCoverageVoteChanged }) {
                 confirmText={confirmConfig.confirmText}
             />
 
-            <ConfirmModal
-                isOpen={calendarExportConfirmOpen}
-                onClose={() => setCalendarExportConfirmOpen(false)}
-                onConfirm={() => { setCalendarExportConfirmOpen(false); handleCalendarExport() }}
-                title="Dienste exportieren"
-                message="Deine Dienste für diesen Monat werden als Kalenderdatei (.ics) heruntergeladen. Diese Datei kannst du in Google Calendar, Apple Kalender oder Outlook importieren."
-                confirmText="Exportieren"
-                cancelText="Abbrechen"
-                icon={Calendar}
-            />
+            <ActionSheet isOpen={calendarMenuOpen} onClose={() => setCalendarMenuOpen(false)} title="Kalender">
+                {/* Monats-Export */}
+                <div className="mb-5">
+                    <h4 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-2">Monat exportieren</h4>
+                    <button
+                        onClick={() => { setCalendarMenuOpen(false); handleCalendarExport() }}
+                        className="w-full flex items-center gap-3 p-3 rounded-xl border border-gray-200 hover:border-blue-300 hover:bg-blue-50/50 transition-colors text-left"
+                    >
+                        <div className="p-2 bg-blue-50 rounded-lg text-blue-600 shrink-0">
+                            <Download size={16} />
+                        </div>
+                        <div>
+                            <div className="text-sm font-medium text-gray-900">{format(currentDate, 'MMMM yyyy', { locale: de })} als .ics</div>
+                            <div className="text-xs text-gray-400">Einmaliger Download für diesen Monat</div>
+                        </div>
+                    </button>
+                </div>
+
+                {/* Kalender-Abo */}
+                <div>
+                    <h4 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-2">Kalender abonnieren</h4>
+                    <CalendarSync userId={user.id} />
+                </div>
+            </ActionSheet>
 
             <AlertModal
                 isOpen={alertConfig.isOpen}

--- a/supabase/functions/calendar-feed/index.ts
+++ b/supabase/functions/calendar-feed/index.ts
@@ -1,0 +1,183 @@
+// Calendar Feed - Serves iCal subscription for external calendar apps
+// URL: GET /functions/v1/calendar-feed?token=<uuid>
+// Deploy: supabase functions deploy calendar-feed --no-verify-jwt
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+// --- iCal generation (ported from src/utils/calendarExport.js) ---
+
+const SHIFT_TYPE_NAMES: Record<string, string> = {
+    'TD1': 'Tagdienst 1',
+    'TD2': 'Tagdienst 2',
+    'ND': 'Nachtdienst',
+    'DBD': 'Doppelbesetzter Dienst',
+    'TEAM': 'Teamsitzung',
+    'FORTBILDUNG': 'Fortbildung',
+    'EINSCHULUNG': 'Einschulungstermin',
+    'MITARBEITERGESPRAECH': 'Mitarbeitergespräch',
+    'SONSTIGES': 'Sonstiges',
+    'SUPERVISION': 'Supervision',
+    'AST': 'Anlaufstelle',
+}
+
+function formatToICalDate(date: string | Date): string {
+    const d = new Date(date)
+    return d.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '')
+}
+
+function escapeICalText(text: string): string {
+    if (!text) return ''
+    return text
+        .replace(/\\/g, '\\\\')
+        .replace(/;/g, '\\;')
+        .replace(/,/g, '\\,')
+        .replace(/\n/g, '\\n')
+}
+
+interface Shift {
+    id: number
+    type: string
+    title?: string
+    start_time: string
+    end_time: string
+}
+
+function shiftToVEvent(shift: Shift, userName: string): string {
+    const title = shift.title || SHIFT_TYPE_NAMES[shift.type] || shift.type
+    const description = `Dienst: ${title}${userName ? `\\nMitarbeiter: ${userName}` : ''}`
+
+    const lines = [
+        'BEGIN:VEVENT',
+        `UID:${shift.id}@wobeplaner.app`,
+        `DTSTAMP:${formatToICalDate(new Date())}`,
+        `DTSTART:${formatToICalDate(shift.start_time)}`,
+        `DTEND:${formatToICalDate(shift.end_time)}`,
+        `SUMMARY:${escapeICalText(title)}`,
+        `DESCRIPTION:${escapeICalText(description)}`,
+        'STATUS:CONFIRMED',
+        'TRANSP:OPAQUE',
+        'BEGIN:VALARM',
+        'ACTION:DISPLAY',
+        'DESCRIPTION:Dienst in 1 Stunde',
+        'TRIGGER:-PT1H',
+        'END:VALARM',
+        'END:VEVENT',
+    ]
+
+    return lines.join('\r\n')
+}
+
+function generateICalFromShifts(shifts: Shift[], userName: string): string {
+    const header = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//WoBePlaner//Dienstplan Export//DE',
+        'CALSCALE:GREGORIAN',
+        'METHOD:PUBLISH',
+        'X-WR-CALNAME:WoBePlaner Dienste',
+        'X-WR-TIMEZONE:Europe/Vienna',
+        'X-PUBLISHED-TTL:PT12H',
+    ].join('\r\n')
+
+    const events = shifts
+        .filter(s => s.start_time && s.end_time)
+        .map(s => shiftToVEvent(s, userName))
+        .join('\r\n')
+
+    const footer = 'END:VCALENDAR'
+
+    return events.length > 0
+        ? `${header}\r\n${events}\r\n${footer}`
+        : `${header}\r\n${footer}`
+}
+
+// --- Edge Function handler ---
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+serve(async (req) => {
+    if (req.method !== 'GET') {
+        return new Response('Method Not Allowed', { status: 405 })
+    }
+
+    try {
+        const url = new URL(req.url)
+        const token = url.searchParams.get('token')
+
+        if (!token || !UUID_REGEX.test(token)) {
+            return new Response('Invalid or missing token', { status: 400 })
+        }
+
+        const supabaseClient = createClient(
+            Deno.env.get('SUPABASE_URL') ?? '',
+            Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+        )
+
+        // Look up token
+        const { data: tokenRecord, error: tokenError } = await supabaseClient
+            .from('calendar_tokens')
+            .select('user_id')
+            .eq('token', token)
+            .eq('is_active', true)
+            .maybeSingle()
+
+        if (tokenError || !tokenRecord) {
+            return new Response('Invalid or revoked token', { status: 403 })
+        }
+
+        const userId = tokenRecord.user_id
+
+        // Get user display name
+        const { data: profile } = await supabaseClient
+            .from('profiles')
+            .select('display_name, full_name')
+            .eq('id', userId)
+            .single()
+
+        const userName = profile?.display_name || profile?.full_name || ''
+
+        // Query shifts: 1 month ago to 3 months ahead
+        const now = new Date()
+        const from = new Date(now)
+        from.setMonth(from.getMonth() - 1)
+        const to = new Date(now)
+        to.setMonth(to.getMonth() + 3)
+
+        const { data: interests, error: shiftError } = await supabaseClient
+            .from('shift_interests')
+            .select('shift_id, shifts!inner(id, type, title, start_time, end_time)')
+            .eq('user_id', userId)
+            .gte('shifts.start_time', from.toISOString())
+            .lte('shifts.start_time', to.toISOString())
+
+        if (shiftError) {
+            console.error('Shift query error:', shiftError)
+            return new Response('Internal error', { status: 500 })
+        }
+
+        // Deduplicate shifts by ID
+        const shiftsMap = new Map<number, Shift>()
+        interests?.forEach((i: { shifts: Shift }) => {
+            if (i.shifts) {
+                shiftsMap.set(i.shifts.id, i.shifts)
+            }
+        })
+        const shifts = Array.from(shiftsMap.values())
+
+        const icalContent = generateICalFromShifts(shifts, userName)
+
+        return new Response(icalContent, {
+            headers: {
+                'Content-Type': 'text/calendar; charset=utf-8',
+                'Content-Disposition': 'inline; filename="dienste.ics"',
+                'Cache-Control': 'no-cache, no-store, must-revalidate',
+                'X-Content-Type-Options': 'nosniff',
+            }
+        })
+
+    } catch (error) {
+        console.error('calendar-feed error:', error)
+        return new Response('Internal Server Error', { status: 500 })
+    }
+})

--- a/supabase/migrations/20260411100000_calendar_tokens.sql
+++ b/supabase/migrations/20260411100000_calendar_tokens.sql
@@ -1,0 +1,30 @@
+-- Calendar sync tokens for iCal subscription URLs
+CREATE TABLE calendar_tokens (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    token       UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    is_active   BOOLEAN NOT NULL DEFAULT true
+);
+
+-- Max one active token per user
+CREATE UNIQUE INDEX calendar_tokens_active_user
+    ON calendar_tokens (user_id) WHERE is_active = true;
+
+-- Fast lookup by token for Edge Function
+CREATE INDEX calendar_tokens_token_lookup
+    ON calendar_tokens (token) WHERE is_active = true;
+
+ALTER TABLE calendar_tokens ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "calendar_tokens_select_own" ON calendar_tokens
+    FOR SELECT TO authenticated
+    USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "calendar_tokens_insert_own" ON calendar_tokens
+    FOR INSERT TO authenticated
+    WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "calendar_tokens_update_own" ON calendar_tokens
+    FOR UPDATE TO authenticated
+    USING (user_id = (SELECT auth.uid()));


### PR DESCRIPTION
fixes #163

## Summary
- Persistente iCal-Abo-URL pro Mitarbeiter — Kalender-Apps (Google, Apple, Outlook) aktualisieren sich automatisch
- Kalender-Button in RosterFeed öffnet jetzt ein ActionSheet mit **Monats-Export** (bestehend) + **Kalender-Abo** (neu)
- Link kann jederzeit widerrufen oder neu generiert werden

## Änderungen

| Datei | Art |
|---|---|
| `supabase/migrations/20260411100000_calendar_tokens.sql` | Neue Tabelle mit RLS + partial unique index (max. 1 aktiver Token pro User) |
| `supabase/functions/calendar-feed/index.ts` | Edge Function (verify_jwt=false), serviert iCal-Feed via Token im Query-Parameter |
| `src/components/CalendarSync.jsx` | UI-Komponente: Token erstellen, kopieren (https / webcal), widerrufen |
| `src/components/RosterFeed.jsx` | Kalender-Button → ActionSheet mit beiden Optionen |

## Deployment-Status
- ✅ DB-Migration bereits auf Production angewendet (via MCP)
- ✅ Edge Function bereits deployed (verify_jwt=false)
- ⏳ Frontend geht bei Merge live via Cloudflare Pages

## Test plan
- [ ] Preview-Deployment: Kalender-Button → ActionSheet öffnet sich
- [ ] "Abo-Link erstellen" → Link wird generiert und angezeigt
- [ ] "Link kopieren" (https) → Link in Google Calendar als externer Kalender hinzufügen → Dienste erscheinen
- [ ] "Apple Kalender (webcal://)" → auf iPhone/Mac → Kalender abonnieren funktioniert
- [ ] "Widerrufen" → bestätigt → Link-UI verschwindet, alter Link liefert 403
- [ ] "Neuer Link" → alter Token wird ungültig, neuer Link funktioniert
- [ ] Monats-Export funktioniert weiterhin wie bisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar subscription functionality enabling users to generate and manage calendar feed links.
  * Calendar feeds can be subscribed to via standard calendar applications using webcal or HTTPS links.
  * Implemented calendar feed sharing with token-based access control.
  * Added ability to copy feed URLs and revoke active subscriptions.
  * Integrated calendar subscription management into the roster UI with a dedicated menu section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->