### PR TITLE
feat: Audit-Protokoll UI — verständliche deutsche Darstellung aller Admin-Aktionen (#167)

### DIFF
--- a/src/components/admin/AdminAuditLog.jsx
+++ b/src/components/admin/AdminAuditLog.jsx
@@ -1,102 +1,80 @@
-import { useState, useEffect, useMemo } from 'react'
-import { format, subDays } from 'date-fns'
+import { useState, useEffect, useMemo, Fragment } from 'react'
+import { format, subDays, parseISO, isValid, isToday, isYesterday } from 'date-fns'
 import { de } from 'date-fns/locale'
 import { supabase } from '../../supabase'
-import { Download, Filter, Calendar, User, Activity } from 'lucide-react'
+import {
+    Download, Filter, Calendar, User, Search, Activity,
+    Plus, Edit, Trash2, UserCheck, UserX, UserPlus, UserMinus,
+    FileCheck, FileX, Clock, Thermometer, ChevronDown, ChevronRight,
+} from 'lucide-react'
+import {
+    ACTION_CATALOG,
+    CATEGORY_LABELS,
+    COLOR_CLASSES,
+    formatAuditEntry,
+    getCatalogEntry,
+} from '../../utils/auditFormatting'
 
-/**
- * =========================================================================
- * AdminAuditLog
- * Displays the immutable log of administrative actions (approvals, edits).
- * Fetches from `admin_actions` table joined with `profiles`.
- * 
- * Priority 1 Improvements:
- * - Filter by time period (7/30/90 days or all)
- * - Filter by action type (shifts, absences, etc.)
- * - Filter by admin
- * - Complete German translations
- * =========================================================================
- */
+const ICON_MAP = {
+    Plus, Edit, Trash2, Calendar, UserCheck, UserX, UserPlus, UserMinus,
+    FileCheck, FileX, Clock, Thermometer, Activity,
+}
+
+const CATEGORY_OPTIONS = [
+    { value: 'all', label: 'Alle Aktionen' },
+    { value: 'shifts', label: CATEGORY_LABELS.shifts },
+    { value: 'absences', label: CATEGORY_LABELS.absences },
+    { value: 'reports', label: CATEGORY_LABELS.reports },
+    { value: 'corrections', label: CATEGORY_LABELS.corrections },
+    { value: 'employees', label: CATEGORY_LABELS.employees },
+]
+
+function getDayLabel(dateStr) {
+    const d = parseISO(dateStr)
+    if (!isValid(d)) return dateStr
+    if (isToday(d)) return 'Heute'
+    if (isYesterday(d)) return 'Gestern'
+    return format(d, 'EEEE, dd.MM.yyyy', { locale: de })
+}
+
+function groupByDay(logs) {
+    const groups = new Map()
+    for (const log of logs) {
+        const d = parseISO(log.created_at)
+        if (!isValid(d)) continue
+        const dayKey = format(d, 'yyyy-MM-dd')
+        if (!groups.has(dayKey)) groups.set(dayKey, [])
+        groups.get(dayKey).push(log)
+    }
+    return Array.from(groups.entries()).map(([day, items]) => ({ day, items }))
+}
+
 export default function AdminAuditLog() {
     const [logs, setLogs] = useState([])
     const [loading, setLoading] = useState(true)
     const [errorMsg, setErrorMsg] = useState(null)
+    const [expanded, setExpanded] = useState(new Set())
 
-    // Filter state
-    const [timePeriod, setTimePeriod] = useState('30') // days: '7', '30', '90', 'all'
-    const [actionFilter, setActionFilter] = useState('all') // 'all', 'shifts', 'absences', 'reports', 'other'
-    const [adminFilter, setAdminFilter] = useState('all') // 'all' or admin_id
+    const [timePeriod, setTimePeriod] = useState('30')
+    const [categoryFilter, setCategoryFilter] = useState('all')
+    const [actionFilter, setActionFilter] = useState('all')
+    const [adminFilter, setAdminFilter] = useState('all')
+    const [employeeFilter, setEmployeeFilter] = useState('all')
+    const [searchTerm, setSearchTerm] = useState('')
     const [showFilters, setShowFilters] = useState(false)
-
-    // All action types with German translations
-    const actionBadges = {
-        // Shift actions
-        'shift_created': { bg: 'bg-green-50', text: 'text-green-700', label: 'Schicht erstellt', category: 'shifts' },
-        'shift_updated': { bg: 'bg-blue-50', text: 'text-blue-700', label: 'Schicht bearbeitet', category: 'shifts' },
-        'shift_deleted': { bg: 'bg-red-50', text: 'text-red-700', label: 'Schicht gelöscht', category: 'shifts' },
-
-        // Absence actions (English)
-        'absence_approved': { bg: 'bg-green-50', text: 'text-green-700', label: 'Urlaub genehmigt', category: 'absences' },
-        'absence_rejected': { bg: 'bg-red-50', text: 'text-red-700', label: 'Urlaub abgelehnt', category: 'absences' },
-
-        // Absence actions (German from DB)
-        'absence_genehmigt': { bg: 'bg-green-50', text: 'text-green-700', label: 'Urlaub genehmigt', category: 'absences' },
-        'absence_abgelehnt': { bg: 'bg-red-50', text: 'text-red-700', label: 'Urlaub abgelehnt', category: 'absences' },
-        'absence_storniert': { bg: 'bg-orange-50', text: 'text-orange-700', label: 'Urlaub storniert', category: 'absences' },
-        'urlaub_genehmigt': { bg: 'bg-green-50', text: 'text-green-700', label: 'Urlaub genehmigt', category: 'absences' },
-        'urlaub_abgelehnt': { bg: 'bg-red-50', text: 'text-red-700', label: 'Urlaub abgelehnt', category: 'absences' },
-        'krankmeldung': { bg: 'bg-orange-50', text: 'text-orange-700', label: 'Krankmeldung', category: 'absences' },
-
-        // Report actions
-        'report_approved': { bg: 'bg-green-50', text: 'text-green-700', label: 'Bericht genehmigt', category: 'reports' },
-        'bericht_genehmigt': { bg: 'bg-green-50', text: 'text-green-700', label: 'Bericht genehmigt', category: 'reports' },
-
-        // Correction actions
-        'correction_added': { bg: 'bg-yellow-50', text: 'text-yellow-700', label: 'Korrektur hinzugefügt', category: 'other' },
-        'korrektur': { bg: 'bg-yellow-50', text: 'text-yellow-700', label: 'Korrektur', category: 'other' },
-
-        // Employee actions
-        'employee_created': { bg: 'bg-purple-50', text: 'text-purple-700', label: 'Mitarbeiter erstellt', category: 'other' },
-        'employee_updated': { bg: 'bg-blue-50', text: 'text-blue-700', label: 'Mitarbeiter aktualisiert', category: 'other' },
-        'employee_invited': { bg: 'bg-purple-50', text: 'text-purple-700', label: 'Mitarbeiter eingeladen', category: 'other' },
-        'employee_deactivated': { bg: 'bg-red-50', text: 'text-red-700', label: 'Mitarbeiter deaktiviert', category: 'other' },
-        'employee_reactivated': { bg: 'bg-green-50', text: 'text-green-700', label: 'Mitarbeiter reaktiviert', category: 'other' },
-        'deactivate_user': { bg: 'bg-red-50', text: 'text-red-700', label: 'Mitarbeiter deaktiviert', category: 'other' },
-        'reactivate_user': { bg: 'bg-green-50', text: 'text-green-700', label: 'Mitarbeiter reaktiviert', category: 'other' },
-
-        // Time entry actions
-        'time_entry_approved': { bg: 'bg-teal-50', text: 'text-teal-700', label: 'Zeiteintrag genehmigt', category: 'reports' },
-
-        // Balance correction actions
-        'create_correction': { bg: 'bg-yellow-50', text: 'text-yellow-700', label: 'Korrektur erstellt', category: 'other' },
-        'balance_correction_deleted': { bg: 'bg-red-50', text: 'text-red-700', label: 'Korrektur gelöscht', category: 'other' },
-
-        // Report actions
-        'approve_report': { bg: 'bg-green-50', text: 'text-green-700', label: 'Bericht genehmigt', category: 'reports' },
-        'reject_report': { bg: 'bg-red-50', text: 'text-red-700', label: 'Bericht abgelehnt', category: 'reports' },
-
-        // Sick report
-        'sick_report_created': { bg: 'bg-orange-50', text: 'text-orange-700', label: 'Krankmeldung erfasst', category: 'absences' },
-    }
-
-    const getActionBadge = (action) => {
-        return actionBadges[action] || { bg: 'bg-gray-50', text: 'text-gray-700', label: action, category: 'other' }
-    }
 
     const fetchLogs = async () => {
         setLoading(true)
         setErrorMsg(null)
 
-        // Build query with time filter
         let query = supabase
             .from('admin_actions')
             .select('*')
             .order('created_at', { ascending: false })
             .limit(500)
 
-        // Apply time period filter
         if (timePeriod !== 'all') {
-            const cutoffDate = subDays(new Date(), parseInt(timePeriod)).toISOString()
+            const cutoffDate = subDays(new Date(), Number.parseInt(timePeriod, 10)).toISOString()
             query = query.gte('created_at', cutoffDate)
         }
 
@@ -106,276 +84,169 @@ export default function AdminAuditLog() {
             console.error(error)
             setErrorMsg(error.message)
             setLogs([])
-        } else if (logsData) {
-            // Collect IDs
-            const userIds = new Set()
-            logsData.forEach(l => {
-                if (l.admin_id) userIds.add(l.admin_id)
-                if (l.target_user_id) userIds.add(l.target_user_id)
-            })
-
-            // Fetch profiles
-            const { data: profiles } = await supabase
-                .from('profiles')
-                .select('id, full_name')
-                .in('id', Array.from(userIds))
-
-            const nameMap = {}
-            profiles?.forEach(p => nameMap[p.id] = p.full_name)
-
-            // Enrich logs
-            const enriched = logsData.map(l => ({
-                ...l,
-                admin: { full_name: nameMap[l.admin_id] || 'Unbekannt', id: l.admin_id },
-                target: { full_name: nameMap[l.target_user_id] || null }
-            }))
-
-            setLogs(enriched)
+            setLoading(false)
+            return
         }
+
+        const userIds = new Set()
+        logsData?.forEach(l => {
+            if (l.admin_id) userIds.add(l.admin_id)
+            if (l.target_user_id) userIds.add(l.target_user_id)
+        })
+
+        const { data: profiles } = await supabase
+            .from('profiles')
+            .select('id, full_name')
+            .in('id', Array.from(userIds))
+
+        const nameMap = {}
+        profiles?.forEach(p => { nameMap[p.id] = p.full_name })
+
+        const enriched = (logsData || []).map(l => ({
+            ...l,
+            admin: { full_name: nameMap[l.admin_id] || 'Unbekannt', id: l.admin_id },
+            target: { full_name: nameMap[l.target_user_id] || null, id: l.target_user_id },
+        }))
+
+        setLogs(enriched)
         setLoading(false)
     }
 
     useEffect(() => { fetchLogs() }, [timePeriod])
 
-    // Get unique admins for filter dropdown
-    const uniqueAdmins = useMemo(() => {
-        const admins = new Map()
-        logs.forEach(l => {
-            if (l.admin?.id && l.admin?.full_name) {
-                admins.set(l.admin.id, l.admin.full_name)
-            }
-        })
-        return Array.from(admins, ([id, name]) => ({ id, name }))
+    const formattedLogs = useMemo(() => {
+        return logs.map(log => ({ log, formatted: formatAuditEntry(log) }))
     }, [logs])
 
-    // Filtered logs based on action type and admin
+    const uniqueAdmins = useMemo(() => {
+        const m = new Map()
+        logs.forEach(l => { if (l.admin?.id && l.admin?.full_name) m.set(l.admin.id, l.admin.full_name) })
+        return Array.from(m, ([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name))
+    }, [logs])
+
+    const uniqueEmployees = useMemo(() => {
+        const m = new Map()
+        logs.forEach(l => { if (l.target?.id && l.target?.full_name) m.set(l.target.id, l.target.full_name) })
+        return Array.from(m, ([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name))
+    }, [logs])
+
+    const actionOptionsForCategory = useMemo(() => {
+        const entries = Object.entries(ACTION_CATALOG)
+        const filtered = categoryFilter === 'all'
+            ? entries
+            : entries.filter(([, v]) => v.category === categoryFilter)
+        return filtered.map(([key, v]) => ({ value: key, label: v.label }))
+            .sort((a, b) => a.label.localeCompare(b.label))
+    }, [categoryFilter])
+
     const filteredLogs = useMemo(() => {
-        return logs.filter(log => {
-            // Action type filter
-            if (actionFilter !== 'all') {
-                const badge = getActionBadge(log.action)
-                if (badge.category !== actionFilter) return false
+        const search = searchTerm.trim().toLowerCase()
+        return formattedLogs.filter(({ log, formatted }) => {
+            if (categoryFilter !== 'all' && formatted.category !== categoryFilter) return false
+            if (actionFilter !== 'all' && formatted.actionKey !== actionFilter) return false
+            if (adminFilter !== 'all' && log.admin?.id !== adminFilter) return false
+            if (employeeFilter !== 'all' && log.target?.id !== employeeFilter) return false
+            if (search) {
+                const haystack = [
+                    formatted.adminName, formatted.targetName,
+                    formatted.label, formatted.headline, formatted.summary,
+                ].filter(Boolean).join(' ').toLowerCase()
+                if (!haystack.includes(search)) return false
             }
-
-            // Admin filter
-            if (adminFilter !== 'all' && log.admin?.id !== adminFilter) {
-                return false
-            }
-
             return true
         })
-    }, [logs, actionFilter, adminFilter])
+    }, [formattedLogs, categoryFilter, actionFilter, adminFilter, employeeFilter, searchTerm])
 
-    // Get display label for target
-    const getTargetLabel = (log) => {
-        if (log.target?.full_name) {
-            return log.target.full_name
-        }
+    const grouped = useMemo(() => groupByDay(filteredLogs.map(x => x.log)), [filteredLogs])
+    const formattedMap = useMemo(() => {
+        const m = new Map()
+        filteredLogs.forEach(({ log, formatted }) => m.set(log.id, formatted))
+        return m
+    }, [filteredLogs])
 
-        if (log.action?.includes('shift') && log.changes) {
-            const changes = log.changes.changes || log.changes
-            const startTime = changes?.start_time || changes?.after?.start_time
-            if (startTime) {
-                try {
-                    return `Schicht ${format(new Date(startTime), 'dd.MM.yyyy', { locale: de })}`
-                } catch {
-                    // Ignore
-                }
-            }
-        }
-
-        if (log.entity_id) {
-            return `ID: ${String(log.entity_id).slice(0, 8)}...`
-        }
-
-        return '-'
-    }
-
-    const renderChanges = (changes) => {
-        if (!changes) return null
-
-        // Status change with context (enriched absence logs)
-        if (changes.before?.status && changes.after?.status) {
-            return (
-                <div className="space-y-1">
-                    <div className="flex items-center gap-2 text-xs">
-                        <span className="px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 line-through">{changes.before.status}</span>
-                        <span>➜</span>
-                        <span className="px-1.5 py-0.5 rounded bg-blue-50 text-blue-700 font-bold">{changes.after.status}</span>
-                    </div>
-                    {changes.context && (
-                        <div className="text-[10px] text-gray-400">
-                            {changes.context.type && <span>{changes.context.type}</span>}
-                            {changes.context.start_date && changes.context.end_date && (
-                                <span> ({changes.context.start_date} bis {changes.context.end_date})</span>
-                            )}
-                        </div>
-                    )}
-                </div>
-            )
-        }
-
-        // Before/After diff (employee_updated, shift_updated with before/after, time_entry_approved)
-        if (changes.before && changes.after && !changes.before.status) {
-            const allKeys = [...new Set([...Object.keys(changes.before || {}), ...Object.keys(changes.after || {})])]
-            const changedKeys = allKeys.filter(k => JSON.stringify(changes.before?.[k]) !== JSON.stringify(changes.after?.[k]))
-            if (changedKeys.length > 0) {
-                return (
-                    <div className="space-y-0.5">
-                        {changedKeys.slice(0, 4).map(key => (
-                            <div key={key} className="text-[10px]">
-                                <span className="text-gray-400">{key}: </span>
-                                <span className="text-red-400 line-through">{String(changes.before?.[key] ?? '-')}</span>
-                                <span className="text-gray-300"> ➜ </span>
-                                <span className="text-green-600 font-medium">{String(changes.after?.[key] ?? '-')}</span>
-                            </div>
-                        ))}
-                        {changedKeys.length > 4 && <div className="text-[10px] text-gray-300">+{changedKeys.length - 4} weitere</div>}
-                    </div>
-                )
-            }
-        }
-
-        // Sick report
-        if (changes.after?.type === 'Krank' && changes.after?.start_date) {
-            return (
-                <div className="text-xs text-gray-600">
-                    {changes.after.start_date} bis {changes.after.end_date}
-                    {changes.after.planned_hours > 0 && <span className="ml-1">({changes.after.planned_hours}h)</span>}
-                    {changes.after.affected_shifts?.length > 0 && (
-                        <span className="ml-1 text-gray-400">({changes.after.affected_shifts.length} Schichten betroffen)</span>
-                    )}
-                </div>
-            )
-        }
-
-        // Balance correction deleted
-        if (changes.before?.correction_hours !== undefined && !changes.after) {
-            return (
-                <div className="text-xs text-gray-600">
-                    {changes.before.correction_hours > 0 ? '+' : ''}{changes.before.correction_hours}h
-                    {changes.before.reason && <span className="text-gray-400 ml-1">({changes.before.reason})</span>}
-                </div>
-            )
-        }
-
-        // Shift changes (legacy format)
-        const shiftChanges = changes.changes || changes
-        if (shiftChanges?.start_time || shiftChanges?.end_time) {
-            try {
-                const start = shiftChanges.start_time ? format(new Date(shiftChanges.start_time), 'dd.MM. HH:mm', { locale: de }) : null
-                const end = shiftChanges.end_time ? format(new Date(shiftChanges.end_time), 'HH:mm', { locale: de }) : null
-                if (start && end) {
-                    return <span className="text-xs text-gray-600">{start} - {end}</span>
-                }
-            } catch {
-                // Fall through
-            }
-        }
-
-        const display = typeof changes === 'object' ? JSON.stringify(changes) : changes
-        return <pre className="text-[10px] text-gray-400 overflow-hidden whitespace-nowrap text-ellipsis max-w-xs">{display}</pre>
-    }
-
-    // Format changes for CSV export
-    const formatChangesText = (log) => {
-        const changes = log.changes
-        if (!changes) return '-'
-
-        if (changes.before?.status && changes.after?.status) {
-            return `Status: ${changes.before.status} → ${changes.after.status}`
-        }
-
-        const shiftChanges = changes.changes || changes
-        if (shiftChanges?.start_time || shiftChanges?.end_time) {
-            try {
-                const start = shiftChanges.start_time ? format(new Date(shiftChanges.start_time), 'HH:mm', { locale: de }) : null
-                const end = shiftChanges.end_time ? format(new Date(shiftChanges.end_time), 'HH:mm', { locale: de }) : null
-                if (start && end) return `Neue Zeit: ${start} - ${end}`
-                if (start) return `Neue Startzeit: ${start}`
-                if (end) return `Neue Endzeit: ${end}`
-            } catch {
-                // Fall through
-            }
-        }
-
-        if (shiftChanges?.title !== undefined) {
-            return shiftChanges.title ? `Neuer Titel: ${shiftChanges.title}` : 'Titel entfernt'
-        }
-
-        return typeof changes === 'object' ? JSON.stringify(changes) : String(changes)
-    }
-
-    // Export filtered logs as CSV
-    const exportCSV = () => {
-        const headers = ['Datum', 'Admin', 'Aktion', 'Ziel', 'Details']
-        const rows = filteredLogs.map(log => {
-            const badge = getActionBadge(log.action)
-            return [
-                format(new Date(log.created_at), 'dd.MM.yyyy HH:mm'),
-                log.admin?.full_name || 'System',
-                badge.label,
-                getTargetLabel(log),
-                formatChangesText(log)
-            ]
+    const toggleExpand = (id) => {
+        setExpanded(prev => {
+            const next = new Set(prev)
+            if (next.has(id)) next.delete(id); else next.add(id)
+            return next
         })
+    }
 
+    const exportCSV = () => {
+        const headers = ['Datum', 'Admin', 'Aktion', 'Mitarbeiter', 'Zusammenfassung']
+        const rows = filteredLogs.map(({ log, formatted }) => ([
+            format(parseISO(log.created_at), 'dd.MM.yyyy HH:mm'),
+            formatted.adminName || 'System',
+            formatted.label,
+            formatted.targetName || '—',
+            formatted.summary || formatted.headline,
+        ]))
         const csvContent = [
             headers.join(';'),
-            ...rows.map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(';'))
+            ...rows.map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(';')),
         ].join('\n')
-
         const blob = new Blob(['\ufeff' + csvContent], { type: 'text/csv;charset=utf-8;' })
         const url = URL.createObjectURL(blob)
         const link = document.createElement('a')
         link.href = url
-        link.download = `audit-log-${format(new Date(), 'yyyy-MM-dd')}.csv`
+        link.download = `audit-protokoll-${format(new Date(), 'yyyy-MM-dd')}.csv`
         link.click()
         URL.revokeObjectURL(url)
     }
 
     return (
         <div>
-            {/* Header */}
-            <div className="flex justify-between items-center mb-4">
-                <h2 className="text-xl font-bold">Audit Log</h2>
-                <div className="flex gap-2">
+            <div className="flex flex-col gap-3 mb-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-3">
+                    <h2 className="text-xl font-bold">Audit-Protokoll</h2>
+                    <span className="text-xs text-gray-400">{filteredLogs.length} {filteredLogs.length === 1 ? 'Eintrag' : 'Einträge'}</span>
+                </div>
+                <div className="flex gap-2 flex-wrap">
+                    <div className="relative flex-1 min-w-[180px]">
+                        <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                        <input
+                            type="search"
+                            value={searchTerm}
+                            onChange={(e) => setSearchTerm(e.target.value)}
+                            placeholder="Suche nach Mitarbeiter, Aktion…"
+                            className="w-full pl-9 pr-3 py-1.5 text-sm border border-gray-200 rounded-lg bg-white focus:ring-2 focus:ring-teal-400 focus:outline-none"
+                        />
+                    </div>
                     <button
-                        onClick={() => setShowFilters(!showFilters)}
-                        className={`text-sm px-3 py-1.5 rounded-lg flex items-center gap-2 transition-colors border ${showFilters ? 'bg-blue-50 text-blue-700 border-blue-200' : 'bg-gray-50 hover:bg-gray-100 border-gray-200'
-                            }`}
+                        onClick={() => setShowFilters(v => !v)}
+                        className={`text-sm px-3 py-1.5 rounded-lg flex items-center gap-2 border transition-colors ${showFilters ? 'bg-blue-50 text-blue-700 border-blue-200' : 'bg-gray-50 hover:bg-gray-100 border-gray-200'}`}
                     >
                         <Filter size={14} />
                         Filter
                     </button>
                     <button
                         onClick={exportCSV}
-                        className="text-sm bg-green-50 hover:bg-green-100 text-green-700 border border-green-200 px-3 py-1.5 rounded-lg flex items-center gap-2 transition-colors"
                         disabled={filteredLogs.length === 0}
+                        className="text-sm bg-green-50 hover:bg-green-100 text-green-700 border border-green-200 px-3 py-1.5 rounded-lg flex items-center gap-2 transition-colors disabled:opacity-50"
                     >
                         <Download size={14} />
-                        Export CSV
+                        CSV
                     </button>
-                    <button onClick={fetchLogs} className="text-sm bg-gray-50 hover:bg-gray-100 border px-3 py-1.5 rounded-lg transition-colors">
+                    <button
+                        onClick={fetchLogs}
+                        className="text-sm bg-gray-50 hover:bg-gray-100 border border-gray-200 px-3 py-1.5 rounded-lg transition-colors"
+                    >
                         Aktualisieren
                     </button>
                 </div>
             </div>
 
-            {/* Filters */}
             {showFilters && (
                 <div className="bg-gray-50/50 rounded-xl p-4 mb-4 shadow-[0_2px_10px_rgb(0,0,0,0.04)]">
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                        {/* Time Period Filter */}
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                         <div>
                             <label className="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase mb-1">
-                                <Calendar size={12} />
-                                Zeitraum
+                                <Calendar size={12} /> Zeitraum
                             </label>
                             <select
                                 value={timePeriod}
                                 onChange={(e) => setTimePeriod(e.target.value)}
-                                className="w-full px-3 py-2 border rounded-lg text-sm bg-white"
+                                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white"
                             >
                                 <option value="7">Letzte 7 Tage</option>
                                 <option value="30">Letzte 30 Tage</option>
@@ -383,46 +254,58 @@ export default function AdminAuditLog() {
                                 <option value="all">Alle</option>
                             </select>
                         </div>
-
-                        {/* Action Type Filter */}
                         <div>
                             <label className="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase mb-1">
-                                <Activity size={12} />
-                                Aktionstyp
+                                <Activity size={12} /> Kategorie
+                            </label>
+                            <select
+                                value={categoryFilter}
+                                onChange={(e) => { setCategoryFilter(e.target.value); setActionFilter('all') }}
+                                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white"
+                            >
+                                {CATEGORY_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                            </select>
+                        </div>
+                        <div>
+                            <label className="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase mb-1">
+                                <Activity size={12} /> Spezifische Aktion
                             </label>
                             <select
                                 value={actionFilter}
                                 onChange={(e) => setActionFilter(e.target.value)}
-                                className="w-full px-3 py-2 border rounded-lg text-sm bg-white"
+                                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white"
                             >
-                                <option value="all">Alle Aktionen</option>
-                                <option value="shifts">Schichten</option>
-                                <option value="absences">Urlaub/Krankmeldung</option>
-                                <option value="reports">Berichte</option>
-                                <option value="other">Sonstiges</option>
+                                <option value="all">Alle</option>
+                                {actionOptionsForCategory.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
                             </select>
                         </div>
-
-                        {/* Admin Filter */}
                         <div>
                             <label className="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase mb-1">
-                                <User size={12} />
-                                Admin
+                                <User size={12} /> Admin
                             </label>
                             <select
                                 value={adminFilter}
                                 onChange={(e) => setAdminFilter(e.target.value)}
-                                className="w-full px-3 py-2 border rounded-lg text-sm bg-white"
+                                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white"
                             >
                                 <option value="all">Alle Admins</option>
-                                {uniqueAdmins.map(admin => (
-                                    <option key={admin.id} value={admin.id}>{admin.name}</option>
-                                ))}
+                                {uniqueAdmins.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
+                            </select>
+                        </div>
+                        <div>
+                            <label className="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase mb-1">
+                                <User size={12} /> Betroffener Mitarbeiter
+                            </label>
+                            <select
+                                value={employeeFilter}
+                                onChange={(e) => setEmployeeFilter(e.target.value)}
+                                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white"
+                            >
+                                <option value="all">Alle Mitarbeiter</option>
+                                {uniqueEmployees.map(e => <option key={e.id} value={e.id}>{e.name}</option>)}
                             </select>
                         </div>
                     </div>
-
-                    {/* Filter summary */}
                     <div className="mt-3 text-xs text-gray-500">
                         Zeige {filteredLogs.length} von {logs.length} Einträgen
                     </div>
@@ -431,42 +314,135 @@ export default function AdminAuditLog() {
 
             {errorMsg && <div className="p-3 bg-red-50 text-red-600 rounded-lg text-sm mb-4">{errorMsg}</div>}
 
-            {/* Log entries */}
-            <div className="space-y-3">
-                {filteredLogs.map(log => {
-                    const badge = getActionBadge(log.action)
-                    return (
-                        <div key={log.id} className="bg-white rounded-xl p-4 shadow-[0_2px_10px_rgb(0,0,0,0.04)] hover:shadow-[0_4px_20px_rgb(0,0,0,0.06)] transition-all">
-                            <div className="flex justify-between items-start mb-1">
-                                <div className="flex items-center gap-2">
-                                    <span className="font-bold text-sm text-gray-900">{log.admin?.full_name || 'System'}</span>
-                                    <span className="text-gray-400 text-xs">•</span>
-                                    <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${badge.bg} ${badge.text}`}>
-                                        {badge.label}
-                                    </span>
-                                </div>
-                                <span className="text-xs text-gray-400 tabular-nums">
-                                    {format(new Date(log.created_at), 'dd.MM. HH:mm')}
-                                </span>
-                            </div>
-
-                            <div className="flex items-center gap-2 text-sm mb-2">
-                                <span className="text-gray-500">Ziel:</span>
-                                <span className="font-medium text-gray-800">{getTargetLabel(log)}</span>
-                                {log.entity_type === 'monthly_report' && <span className="text-xs bg-gray-100 px-1 rounded text-gray-500">Monatsbericht</span>}
-                                {log.entity_type === 'absence_request' && <span className="text-xs bg-yellow-100 px-1 rounded text-yellow-800">Antrag</span>}
-                            </div>
-
-                            <div className="bg-gray-50 rounded p-2">
-                                {renderChanges(log.changes)}
-                            </div>
+            <div className="space-y-4">
+                {grouped.map(({ day, items }) => (
+                    <div key={day}>
+                        <div className="flex items-center gap-3 mb-2 px-1">
+                            <span className="text-xs font-bold uppercase text-gray-500 tracking-wide">{getDayLabel(day)}</span>
+                            <div className="flex-1 h-px bg-gray-200" />
+                            <span className="text-xs text-gray-400">{items.length}</span>
                         </div>
-                    )
-                })}
+                        <div className="space-y-2">
+                            {items.map(log => (
+                                <AuditCard
+                                    key={log.id}
+                                    log={log}
+                                    formatted={formattedMap.get(log.id)}
+                                    expanded={expanded.has(log.id)}
+                                    onToggle={() => toggleExpand(log.id)}
+                                />
+                            ))}
+                        </div>
+                    </div>
+                ))}
             </div>
 
-            {loading && <div className="text-center text-gray-400 text-sm py-4">Lade...</div>}
-            {!loading && filteredLogs.length === 0 && <div className="text-center text-gray-400 text-sm py-4">Keine Einträge.</div>}
+            {loading && <div className="text-center text-gray-400 text-sm py-4">Lade…</div>}
+            {!loading && filteredLogs.length === 0 && (
+                <div className="text-center text-gray-400 text-sm py-8">
+                    Keine Admin-Aktionen im gewählten Zeitraum.
+                </div>
+            )}
+        </div>
+    )
+}
+
+function AuditCard({ log, formatted, expanded, onToggle }) {
+    if (!formatted) return null
+    const Icon = ICON_MAP[formatted.icon] || Activity
+    const colors = COLOR_CLASSES[formatted.color] || COLOR_CLASSES.gray
+    const catalogEntry = getCatalogEntry(log.action)
+    const isKnownAction = Boolean(catalogEntry)
+
+    const timeStr = format(parseISO(log.created_at), 'HH:mm', { locale: de })
+    const adminName = formatted.adminName || 'System'
+    const targetName = formatted.targetName
+
+    return (
+        <div className="bg-white rounded-xl p-4 shadow-[0_2px_10px_rgb(0,0,0,0.04)] hover:shadow-[0_4px_20px_rgb(0,0,0,0.06)] transition-all">
+            <div className="flex items-start gap-3">
+                <div className={`w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0 ${colors.ring}`}>
+                    <Icon size={18} className={colors.text} />
+                </div>
+                <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-2 flex-wrap">
+                                <span className={`text-[11px] font-medium px-1.5 py-0.5 rounded ${colors.bg} ${colors.text}`}>
+                                    {formatted.label}
+                                </span>
+                                {!isKnownAction && (
+                                    <span className="text-[10px] text-gray-400 italic">unbekannter Typ</span>
+                                )}
+                            </div>
+                            <div className="font-semibold text-gray-900 mt-0.5 text-sm">
+                                {formatted.headline}
+                            </div>
+                        </div>
+                        <span className="text-xs text-gray-400 tabular-nums flex-shrink-0">{timeStr}</span>
+                    </div>
+
+                    <div className="flex items-center gap-1.5 text-xs text-gray-600 mt-1.5 flex-wrap">
+                        <span className="font-medium">{adminName}</span>
+                        {targetName && (
+                            <>
+                                <span className="text-gray-300">→</span>
+                                <span className="font-medium text-gray-800">{targetName}</span>
+                            </>
+                        )}
+                        {!targetName && formatted.category === 'shifts' && (
+                            <span className="text-gray-400 italic">Dienstplan-weit</span>
+                        )}
+                    </div>
+
+                    {formatted.chips.length > 0 && (
+                        <div className="flex gap-1.5 mt-2 flex-wrap">
+                            {formatted.chips.map((chip, i) => {
+                                const c = COLOR_CLASSES[chip.color] || COLOR_CLASSES.gray
+                                return (
+                                    <span key={i} className={`text-[11px] px-2 py-0.5 rounded-full ${c.bg} ${c.text}`}>
+                                        {chip.label}
+                                    </span>
+                                )
+                            })}
+                        </div>
+                    )}
+
+                    {formatted.diffs.length > 0 && (
+                        <div className="mt-2 bg-gray-50 rounded-lg p-2.5 space-y-1">
+                            {formatted.diffs.map((d, i) => (
+                                <div key={i} className="text-xs grid grid-cols-[minmax(90px,auto)_1fr] gap-2 items-center">
+                                    <span className="text-gray-500">{d.fieldLabel}:</span>
+                                    <div className="flex items-center gap-1.5 flex-wrap min-w-0">
+                                        <span className="text-gray-400 line-through truncate">{d.before}</span>
+                                        <span className="text-gray-300">→</span>
+                                        <span className="text-gray-900 font-medium truncate">{d.after}</span>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+
+                    <button
+                        onClick={onToggle}
+                        className="mt-2 text-[11px] text-gray-400 hover:text-gray-600 flex items-center gap-1"
+                    >
+                        {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                        Rohdaten {expanded ? 'ausblenden' : 'anzeigen'}
+                    </button>
+
+                    {expanded && (
+                        <div className="mt-2 bg-gray-900 text-gray-100 rounded-lg p-3 text-[10px] font-mono overflow-auto max-h-96">
+                            <div className="text-gray-400 mb-1">action: <span className="text-gray-200">{log.action}</span></div>
+                            <div className="text-gray-400 mb-1">resource: <span className="text-gray-200">{log.target_resource_type || '—'} / {log.target_resource_id || '—'}</span></div>
+                            <div className="text-gray-400 mb-1">changes:</div>
+                            <pre className="whitespace-pre-wrap break-all">{JSON.stringify(log.changes, null, 2)}</pre>
+                            <div className="text-gray-400 mb-1 mt-2">metadata:</div>
+                            <pre className="whitespace-pre-wrap break-all">{JSON.stringify(log.metadata, null, 2)}</pre>
+                        </div>
+                    )}
+                </div>
+            </div>
         </div>
     )
 }

--- a/src/utils/auditFormatting.js
+++ b/src/utils/auditFormatting.js
@@ -1,0 +1,626 @@
+import { format, parseISO, isValid, differenceInCalendarDays } from 'date-fns'
+import { de } from 'date-fns/locale'
+
+export const ACTION_CATALOG = {
+    shift_created: { label: 'Schicht erstellt', category: 'shifts', color: 'green', icon: 'Plus' },
+    shift_updated: { label: 'Schicht bearbeitet', category: 'shifts', color: 'blue', icon: 'Edit' },
+    shift_deleted: { label: 'Schicht gelöscht', category: 'shifts', color: 'red', icon: 'Trash2' },
+    generate_roster: { label: 'Dienstplan generiert', category: 'shifts', color: 'green', icon: 'Calendar' },
+    replace_roster: { label: 'Dienstplan ersetzt', category: 'shifts', color: 'orange', icon: 'Calendar' },
+    absence_genehmigt: { label: 'Urlaub genehmigt', category: 'absences', color: 'green', icon: 'UserCheck' },
+    absence_abgelehnt: { label: 'Urlaub abgelehnt', category: 'absences', color: 'red', icon: 'UserX' },
+    absence_storniert: { label: 'Urlaub storniert', category: 'absences', color: 'orange', icon: 'UserX' },
+    sick_report_created: { label: 'Krankmeldung erfasst', category: 'absences', color: 'orange', icon: 'Thermometer' },
+    sick_leave_deleted: { label: 'Krankmeldung gelöscht', category: 'absences', color: 'red', icon: 'Trash2' },
+    sick_leave_shortened: { label: 'Krankmeldung gekürzt', category: 'absences', color: 'amber', icon: 'Edit' },
+    approve_report: { label: 'Monatsbericht genehmigt', category: 'reports', color: 'green', icon: 'FileCheck' },
+    reject_report: { label: 'Monatsbericht abgelehnt', category: 'reports', color: 'red', icon: 'FileX' },
+    time_entry_approved: { label: 'Zeiteintrag bearbeitet', category: 'reports', color: 'teal', icon: 'Clock' },
+    create_correction: { label: 'Saldo-Korrektur', category: 'corrections', color: 'amber', icon: 'Plus' },
+    balance_correction_deleted: { label: 'Saldo-Korrektur gelöscht', category: 'corrections', color: 'red', icon: 'Trash2' },
+    employee_created: { label: 'Mitarbeiter angelegt', category: 'employees', color: 'purple', icon: 'UserPlus' },
+    employee_updated: { label: 'Mitarbeiter bearbeitet', category: 'employees', color: 'blue', icon: 'Edit' },
+    deactivate_user: { label: 'Mitarbeiter deaktiviert', category: 'employees', color: 'red', icon: 'UserMinus' },
+    reactivate_user: { label: 'Mitarbeiter reaktiviert', category: 'employees', color: 'green', icon: 'UserCheck' },
+}
+
+export const ACTION_ALIASES = {
+    absence_approved: 'absence_genehmigt',
+    absence_rejected: 'absence_abgelehnt',
+    urlaub_genehmigt: 'absence_genehmigt',
+    urlaub_abgelehnt: 'absence_abgelehnt',
+    report_approved: 'approve_report',
+    bericht_genehmigt: 'approve_report',
+    correction_added: 'create_correction',
+    korrektur: 'create_correction',
+    employee_invited: 'employee_created',
+    employee_deactivated: 'deactivate_user',
+    employee_reactivated: 'reactivate_user',
+    krankmeldung: 'sick_report_created',
+}
+
+export const CATEGORY_LABELS = {
+    shifts: 'Schichten',
+    absences: 'Urlaub & Krankmeldung',
+    reports: 'Berichte & Zeiteinträge',
+    corrections: 'Saldo-Korrekturen',
+    employees: 'Mitarbeiter',
+}
+
+export const CATEGORY_COLORS = {
+    shifts: { bg: 'bg-blue-50', text: 'text-blue-700', ring: 'bg-blue-100' },
+    absences: { bg: 'bg-orange-50', text: 'text-orange-700', ring: 'bg-orange-100' },
+    reports: { bg: 'bg-teal-50', text: 'text-teal-700', ring: 'bg-teal-100' },
+    corrections: { bg: 'bg-amber-50', text: 'text-amber-700', ring: 'bg-amber-100' },
+    employees: { bg: 'bg-purple-50', text: 'text-purple-700', ring: 'bg-purple-100' },
+}
+
+export const COLOR_CLASSES = {
+    green: { bg: 'bg-green-50', text: 'text-green-700', ring: 'bg-green-100', border: 'border-green-200' },
+    red: { bg: 'bg-red-50', text: 'text-red-700', ring: 'bg-red-100', border: 'border-red-200' },
+    blue: { bg: 'bg-blue-50', text: 'text-blue-700', ring: 'bg-blue-100', border: 'border-blue-200' },
+    orange: { bg: 'bg-orange-50', text: 'text-orange-700', ring: 'bg-orange-100', border: 'border-orange-200' },
+    amber: { bg: 'bg-amber-50', text: 'text-amber-700', ring: 'bg-amber-100', border: 'border-amber-200' },
+    purple: { bg: 'bg-purple-50', text: 'text-purple-700', ring: 'bg-purple-100', border: 'border-purple-200' },
+    teal: { bg: 'bg-teal-50', text: 'text-teal-700', ring: 'bg-teal-100', border: 'border-teal-200' },
+    gray: { bg: 'bg-gray-50', text: 'text-gray-700', ring: 'bg-gray-100', border: 'border-gray-200' },
+}
+
+export const FIELD_LABELS = {
+    start_time: 'Startzeit',
+    end_time: 'Endzeit',
+    start_date: 'Von',
+    end_date: 'Bis',
+    type: 'Typ',
+    status: 'Status',
+    title: 'Titel',
+    full_name: 'Name',
+    email: 'E-Mail',
+    role: 'Rolle',
+    weekly_hours: 'Wochenstunden',
+    vacation_days_per_year: 'Urlaubstage/Jahr',
+    initial_balance: 'Startsaldo',
+    is_active: 'Aktiv',
+    correction_hours: 'Korrekturstunden',
+    previous_total: 'Saldo vorher',
+    target_total: 'Saldo nachher',
+    reason: 'Grund',
+    planned_hours: 'Geplante Stunden',
+    affected_shifts: 'Betroffene Schichten',
+    shifts_marked_urgent: 'Als dringend markiert',
+    date: 'Datum',
+}
+
+export const STATUS_LABELS = {
+    pending: 'Ausstehend',
+    approved: 'Genehmigt',
+    genehmigt: 'Genehmigt',
+    rejected: 'Abgelehnt',
+    abgelehnt: 'Abgelehnt',
+    cancelled: 'Storniert',
+    storniert: 'Storniert',
+    submitted: 'Eingereicht',
+    eingereicht: 'Eingereicht',
+    draft: 'Entwurf',
+    offen: 'Offen',
+    open: 'Offen',
+    true: 'Ja',
+    false: 'Nein',
+}
+
+export const ROLE_LABELS = {
+    admin: 'Administrator',
+    employee: 'Mitarbeiter',
+}
+
+export const SHIFT_TYPE_NAMES = {
+    TD1: 'Tagdienst 1',
+    TD2: 'Tagdienst 2',
+    ND: 'Nachtdienst',
+    DBD: 'Doppelbesetzter Dienst',
+    TEAM: 'Teamsitzung',
+    FORTBILDUNG: 'Fortbildung',
+    EINSCHULUNG: 'Einschulungstermin',
+    MITARBEITERGESPRAECH: 'Mitarbeitergespräch',
+    SONSTIGES: 'Sonstiges',
+    SUPERVISION: 'Supervision',
+    AST: 'Anlaufstelle',
+}
+
+export const ABSENCE_TYPE_LABELS = {
+    Urlaub: 'Urlaub',
+    Zeitausgleich: 'Zeitausgleich',
+    Krank: 'Krankmeldung',
+    Sonstiges: 'Sonstiges',
+}
+
+const MONTH_NAMES = [
+    'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni',
+    'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember',
+]
+
+export function normalizeActionKey(action) {
+    if (!action) return null
+    return ACTION_ALIASES[action] || action
+}
+
+export function getCatalogEntry(action) {
+    const key = normalizeActionKey(action)
+    return ACTION_CATALOG[key] || null
+}
+
+function tryParseDate(value) {
+    if (!value) return null
+    if (value instanceof Date) return isValid(value) ? value : null
+    if (typeof value !== 'string') return null
+    const d = parseISO(value)
+    return isValid(d) ? d : null
+}
+
+function formatDate(value) {
+    const d = tryParseDate(value)
+    if (!d) return value ?? '—'
+    return format(d, 'dd.MM.yyyy', { locale: de })
+}
+
+function formatTime(value) {
+    const d = tryParseDate(value)
+    if (!d) return value ?? '—'
+    return format(d, 'HH:mm', { locale: de })
+}
+
+function formatDateTime(value) {
+    const d = tryParseDate(value)
+    if (!d) return value ?? '—'
+    return format(d, 'dd.MM.yyyy HH:mm', { locale: de })
+}
+
+function formatMonthLabel(yearOrStr, month) {
+    // Accepts (2026, 3) or ('2026-03') or ('2026-03-01')
+    let y, m
+    if (typeof yearOrStr === 'string') {
+        const parts = yearOrStr.split('-')
+        y = parseInt(parts[0], 10)
+        m = parseInt(parts[1], 10)
+    } else {
+        y = yearOrStr
+        m = month
+    }
+    if (!y || !m || m < 1 || m > 12) return null
+    return `${MONTH_NAMES[m - 1]} ${y}`
+}
+
+function formatHours(hours) {
+    if (hours === null || hours === undefined) return '—'
+    const n = Number(hours)
+    if (Number.isNaN(n)) return String(hours)
+    const sign = n > 0 ? '+' : ''
+    return `${sign}${n.toLocaleString('de-DE', { minimumFractionDigits: 1, maximumFractionDigits: 2 })} h`
+}
+
+function formatDateRange(startValue, endValue) {
+    const start = tryParseDate(startValue)
+    const end = tryParseDate(endValue)
+    if (!start) return null
+    const startStr = format(start, 'dd.MM.yyyy', { locale: de })
+    if (!end) return startStr
+    const endStr = format(end, 'dd.MM.yyyy', { locale: de })
+    if (startStr === endStr) return startStr
+    const days = differenceInCalendarDays(end, start) + 1
+    return `${startStr} – ${endStr} (${days} ${days === 1 ? 'Tag' : 'Tage'})`
+}
+
+function shiftTypeLabel(type) {
+    if (!type) return null
+    return SHIFT_TYPE_NAMES[type] || null
+}
+
+function absenceTypeLabel(type) {
+    if (!type) return null
+    return ABSENCE_TYPE_LABELS[type] || null
+}
+
+export function formatValue(key, value) {
+    if (value === null || value === undefined || value === '') return '—'
+
+    if (key === 'status') return STATUS_LABELS[String(value).toLowerCase()] || String(value)
+    if (key === 'role') return ROLE_LABELS[String(value).toLowerCase()] || String(value)
+    if (key === 'is_active') return STATUS_LABELS[String(value)] || (value ? 'Ja' : 'Nein')
+    if (key === 'type') {
+        return shiftTypeLabel(value) || absenceTypeLabel(value) || String(value)
+    }
+    if (key?.endsWith?.('_date') || key === 'date') return formatDate(value)
+    if (key?.endsWith?.('_time')) return formatTime(value)
+    if (key === 'weekly_hours' || key === 'planned_hours') {
+        const n = Number(value)
+        if (Number.isNaN(n)) return String(value)
+        return `${n.toLocaleString('de-DE')} h`
+    }
+    if (key === 'correction_hours' || key === 'previous_total' || key === 'target_total' || key === 'initial_balance') {
+        return formatHours(value)
+    }
+    if (key === 'vacation_days_per_year') return `${Number(value).toLocaleString('de-DE')} Tage`
+    if (typeof value === 'boolean') return value ? 'Ja' : 'Nein'
+    if (Array.isArray(value)) return `${value.length} Einträge`
+    if (typeof value === 'object') return JSON.stringify(value)
+    return String(value)
+}
+
+export function getFieldLabel(key) {
+    return FIELD_LABELS[key] || key
+}
+
+function buildDiffs(before, after, keysAllowList = null) {
+    if (!before || !after) return []
+    const allKeys = new Set([...Object.keys(before), ...Object.keys(after)])
+    const result = []
+    for (const key of allKeys) {
+        if (keysAllowList && !keysAllowList.includes(key)) continue
+        if (JSON.stringify(before[key]) === JSON.stringify(after[key])) continue
+        result.push({
+            field: key,
+            fieldLabel: getFieldLabel(key),
+            before: formatValue(key, before[key]),
+            after: formatValue(key, after[key]),
+        })
+    }
+    return result
+}
+
+function formatShiftEntry(actionKey, log) {
+    const changes = log.changes || {}
+    const metadata = log.metadata || {}
+
+    if (actionKey === 'shift_created') {
+        const date = changes.date || changes.after?.date
+        const type = changes.type || changes.after?.type
+        const start = changes.start_time || changes.after?.start_time
+        const end = changes.end_time || changes.after?.end_time
+        const typeLbl = shiftTypeLabel(type) || 'Schicht'
+        const dateStr = date ? formatDate(date) : (start ? formatDate(start) : null)
+        const timeStr = start && end ? `${formatTime(start)}–${formatTime(end)}` : null
+        const headline = [typeLbl, dateStr && `am ${dateStr}`, timeStr && `(${timeStr})`].filter(Boolean).join(' ')
+        return {
+            headline: headline || 'Schicht erstellt',
+            chips: [],
+            diffs: [],
+            summary: `${typeLbl}${dateStr ? ` am ${dateStr}` : ''}${timeStr ? ` ${timeStr}` : ''} erstellt`,
+        }
+    }
+
+    if (actionKey === 'shift_updated') {
+        const before = changes.before || {}
+        const after = changes.after || {}
+        const type = after.type || before.type
+        const date = after.start_time || before.start_time
+        const typeLbl = shiftTypeLabel(type) || 'Schicht'
+        const dateStr = date ? formatDate(date) : null
+        const diffs = buildDiffs(before, after, ['start_time', 'end_time', 'type', 'title'])
+        const headline = `${typeLbl}${dateStr ? ` am ${dateStr}` : ''} bearbeitet`
+        return {
+            headline,
+            chips: [],
+            diffs,
+            summary: diffs.length
+                ? `${typeLbl}${dateStr ? ` am ${dateStr}` : ''}: ${diffs.map(d => `${d.fieldLabel} ${d.before} → ${d.after}`).join(', ')}`
+                : headline,
+        }
+    }
+
+    if (actionKey === 'shift_deleted') {
+        const deleted = changes.deleted || changes || {}
+        const type = deleted.type
+        const start = deleted.start_time
+        const typeLbl = shiftTypeLabel(type) || 'Schicht'
+        const dateStr = start ? formatDate(start) : null
+        return {
+            headline: `${typeLbl}${dateStr ? ` am ${dateStr}` : ''} gelöscht`,
+            chips: [],
+            diffs: [],
+            summary: `${typeLbl}${dateStr ? ` am ${dateStr}` : ''} gelöscht`,
+        }
+    }
+
+    if (actionKey === 'generate_roster' || actionKey === 'replace_roster') {
+        const monthStr = metadata.month ? formatMonthLabel(metadata.month) : null
+        const created = metadata.created ?? 0
+        const skipped = metadata.skipped ?? 0
+        const deleted = metadata.deleted ?? 0
+        const chips = []
+        if (created) chips.push({ label: `${created} erstellt`, color: 'green' })
+        if (skipped) chips.push({ label: `${skipped} übersprungen`, color: 'gray' })
+        if (deleted) chips.push({ label: `${deleted} gelöscht`, color: 'red' })
+        const verb = actionKey === 'generate_roster' ? 'generiert' : 'ersetzt'
+        const headline = `Dienstplan${monthStr ? ` für ${monthStr}` : ''} ${verb}`
+        return {
+            headline,
+            chips,
+            diffs: [],
+            summary: `${headline} — ${chips.map(c => c.label).join(', ') || 'keine Änderungen'}`,
+        }
+    }
+
+    return null
+}
+
+function formatAbsenceEntry(actionKey, log) {
+    const changes = log.changes || {}
+    const context = changes.context || {}
+    const beforeStatus = changes.before?.status
+    const afterStatus = changes.after?.status
+
+    if (actionKey === 'absence_genehmigt' || actionKey === 'absence_abgelehnt' || actionKey === 'absence_storniert') {
+        const rangeStr = context.start_date ? formatDateRange(context.start_date, context.end_date) : null
+        const typeLbl = absenceTypeLabel(context.type) || 'Urlaub'
+        const verb = actionKey === 'absence_genehmigt' ? 'genehmigt'
+            : actionKey === 'absence_abgelehnt' ? 'abgelehnt' : 'storniert'
+        const headline = `${typeLbl}${rangeStr ? ` ${rangeStr}` : ''} ${verb}`
+        const diffs = beforeStatus && afterStatus ? [{
+            field: 'status',
+            fieldLabel: 'Status',
+            before: formatValue('status', beforeStatus),
+            after: formatValue('status', afterStatus),
+        }] : []
+        return {
+            headline,
+            chips: context.type ? [{ label: typeLbl, color: 'blue' }] : [],
+            diffs,
+            summary: headline,
+        }
+    }
+
+    if (actionKey === 'sick_report_created') {
+        const after = changes.after || {}
+        const rangeStr = after.start_date ? formatDateRange(after.start_date, after.end_date) : null
+        const hours = after.planned_hours
+        const affected = Array.isArray(after.affected_shifts) ? after.affected_shifts.length : null
+        const parts = []
+        if (rangeStr) parts.push(rangeStr)
+        if (hours) parts.push(`${Number(hours).toLocaleString('de-DE')} h`)
+        if (affected !== null) parts.push(`${affected} ${affected === 1 ? 'Schicht' : 'Schichten'} betroffen`)
+        const headline = `Krankmeldung ${parts.join(' · ') || 'erfasst'}`
+        return {
+            headline,
+            chips: [],
+            diffs: [],
+            summary: headline,
+        }
+    }
+
+    if (actionKey === 'sick_leave_deleted') {
+        const before = changes.before || {}
+        const rangeStr = before.start_date ? formatDateRange(before.start_date, before.end_date) : null
+        const reason = log.metadata?.reason
+        return {
+            headline: `Krankmeldung${rangeStr ? ` ${rangeStr}` : ''} gelöscht`,
+            chips: [],
+            diffs: reason ? [{ field: 'reason', fieldLabel: 'Grund', before: '—', after: reason }] : [],
+            summary: `Krankmeldung${rangeStr ? ` ${rangeStr}` : ''} gelöscht${reason ? ` (${reason})` : ''}`,
+        }
+    }
+
+    if (actionKey === 'sick_leave_shortened') {
+        const before = changes.before || {}
+        const after = changes.after || {}
+        const rangeStr = before.start_date ? formatDateRange(before.start_date, before.end_date) : null
+        const diffs = []
+        if (before.end_date && after.end_date) {
+            diffs.push({
+                field: 'end_date',
+                fieldLabel: 'Bis',
+                before: formatDate(before.end_date),
+                after: formatDate(after.end_date),
+            })
+        }
+        return {
+            headline: `Krankmeldung${rangeStr ? ` (${rangeStr})` : ''} gekürzt`,
+            chips: [],
+            diffs,
+            summary: diffs.length
+                ? `Krankmeldung gekürzt — Bis: ${diffs[0].before} → ${diffs[0].after}`
+                : 'Krankmeldung gekürzt',
+        }
+    }
+
+    return null
+}
+
+function formatReportEntry(actionKey, log) {
+    const changes = log.changes || {}
+    const metadata = log.metadata || {}
+
+    if (actionKey === 'approve_report' || actionKey === 'reject_report') {
+        const monthStr = metadata.year && metadata.month ? formatMonthLabel(metadata.year, metadata.month) : null
+        const verb = actionKey === 'approve_report' ? 'genehmigt' : 'abgelehnt'
+        const diffs = []
+        if (changes.before?.status && changes.after?.status) {
+            diffs.push({
+                field: 'status',
+                fieldLabel: 'Status',
+                before: formatValue('status', changes.before.status),
+                after: formatValue('status', changes.after.status),
+            })
+        }
+        return {
+            headline: `Monatsbericht${monthStr ? ` ${monthStr}` : ''} ${verb}`,
+            chips: [],
+            diffs,
+            summary: `Monatsbericht${monthStr ? ` ${monthStr}` : ''} ${verb}`,
+        }
+    }
+
+    if (actionKey === 'time_entry_approved') {
+        const before = changes.before || {}
+        const after = changes.after || {}
+        const dayStr = before.start_time || after.start_time
+            ? formatDate(before.start_time || after.start_time)
+            : null
+        const diffs = buildDiffs(before, after)
+        return {
+            headline: `Zeiteintrag${dayStr ? ` am ${dayStr}` : ''} bearbeitet`,
+            chips: [],
+            diffs,
+            summary: diffs.length
+                ? `Zeiteintrag${dayStr ? ` ${dayStr}` : ''}: ${diffs.map(d => `${d.fieldLabel} ${d.before} → ${d.after}`).join(', ')}`
+                : `Zeiteintrag${dayStr ? ` ${dayStr}` : ''} bearbeitet`,
+        }
+    }
+
+    return null
+}
+
+function formatCorrectionEntry(actionKey, log) {
+    const changes = log.changes || {}
+    const metadata = log.metadata || {}
+
+    if (actionKey === 'create_correction') {
+        const hours = changes.correction_hours
+        const reason = changes.reason
+        const monthStr = metadata.month ? formatMonthLabel(metadata.month) : null
+        const hoursStr = hours !== undefined ? formatHours(hours) : null
+        const diffs = []
+        if (changes.previous_total !== undefined && changes.target_total !== undefined) {
+            diffs.push({
+                field: 'balance',
+                fieldLabel: 'Saldo',
+                before: formatHours(changes.previous_total),
+                after: formatHours(changes.target_total),
+            })
+        }
+        if (reason) {
+            diffs.push({ field: 'reason', fieldLabel: 'Grund', before: '—', after: reason })
+        }
+        return {
+            headline: `Saldo-Korrektur ${hoursStr || ''}${monthStr ? ` (${monthStr})` : ''}`.trim(),
+            chips: [],
+            diffs,
+            summary: `Saldo-Korrektur ${hoursStr || ''}${monthStr ? ` (${monthStr})` : ''}${reason ? ` — ${reason}` : ''}`.trim(),
+        }
+    }
+
+    if (actionKey === 'balance_correction_deleted') {
+        const before = changes.before || {}
+        const hoursStr = before.correction_hours !== undefined ? formatHours(before.correction_hours) : null
+        const reason = before.reason
+        return {
+            headline: `Saldo-Korrektur${hoursStr ? ` ${hoursStr}` : ''} gelöscht`,
+            chips: [],
+            diffs: reason ? [{ field: 'reason', fieldLabel: 'Grund', before: '—', after: reason }] : [],
+            summary: `Saldo-Korrektur${hoursStr ? ` ${hoursStr}` : ''} gelöscht${reason ? ` (${reason})` : ''}`,
+        }
+    }
+
+    return null
+}
+
+function formatEmployeeEntry(actionKey, log) {
+    const changes = log.changes || {}
+    const after = changes.after || {}
+
+    if (actionKey === 'employee_created') {
+        const nameChip = after.full_name ? after.full_name : null
+        const headline = nameChip ? `${nameChip} angelegt` : 'Mitarbeiter angelegt'
+        const diffs = []
+        const fields = ['email', 'role', 'weekly_hours', 'vacation_days_per_year', 'initial_balance']
+        for (const key of fields) {
+            if (after[key] !== undefined && after[key] !== null && after[key] !== '') {
+                diffs.push({
+                    field: key,
+                    fieldLabel: getFieldLabel(key),
+                    before: '—',
+                    after: formatValue(key, after[key]),
+                })
+            }
+        }
+        return {
+            headline,
+            chips: [],
+            diffs,
+            summary: `${headline}${diffs.length ? ` — ${diffs.map(d => `${d.fieldLabel}: ${d.after}`).join(', ')}` : ''}`,
+        }
+    }
+
+    if (actionKey === 'employee_updated') {
+        const before = changes.before || {}
+        const diffs = buildDiffs(before, after)
+        return {
+            headline: 'Mitarbeiter bearbeitet',
+            chips: [],
+            diffs,
+            summary: diffs.length
+                ? `Mitarbeiter bearbeitet — ${diffs.map(d => `${d.fieldLabel}: ${d.before} → ${d.after}`).join(', ')}`
+                : 'Mitarbeiter bearbeitet',
+        }
+    }
+
+    if (actionKey === 'deactivate_user') {
+        return {
+            headline: 'Mitarbeiter deaktiviert',
+            chips: [],
+            diffs: [],
+            summary: 'Mitarbeiter deaktiviert',
+        }
+    }
+
+    if (actionKey === 'reactivate_user') {
+        return {
+            headline: 'Mitarbeiter reaktiviert',
+            chips: [],
+            diffs: [],
+            summary: 'Mitarbeiter reaktiviert',
+        }
+    }
+
+    return null
+}
+
+function formatGenericEntry(log) {
+    const changes = log.changes || {}
+    if (changes.before && changes.after) {
+        const diffs = buildDiffs(changes.before, changes.after)
+        return {
+            headline: log.action || 'Aktion',
+            chips: [],
+            diffs,
+            summary: diffs.map(d => `${d.fieldLabel}: ${d.before} → ${d.after}`).join(', ') || (log.action || ''),
+        }
+    }
+    return { headline: log.action || 'Aktion', chips: [], diffs: [], summary: log.action || '' }
+}
+
+export function formatAuditEntry(log) {
+    const actionKey = normalizeActionKey(log.action)
+    const catalog = ACTION_CATALOG[actionKey]
+
+    const base = {
+        actionKey,
+        rawAction: log.action,
+        label: catalog?.label || log.action || 'Unbekannte Aktion',
+        category: catalog?.category || 'other',
+        color: catalog?.color || 'gray',
+        icon: catalog?.icon || 'Activity',
+        adminName: log.admin?.full_name || null,
+        targetName: log.target?.full_name || null,
+        createdAt: log.created_at,
+    }
+
+    const category = catalog?.category
+    let formatted = null
+    if (category === 'shifts') formatted = formatShiftEntry(actionKey, log)
+    else if (category === 'absences') formatted = formatAbsenceEntry(actionKey, log)
+    else if (category === 'reports') formatted = formatReportEntry(actionKey, log)
+    else if (category === 'corrections') formatted = formatCorrectionEntry(actionKey, log)
+    else if (category === 'employees') formatted = formatEmployeeEntry(actionKey, log)
+
+    if (!formatted) formatted = formatGenericEntry(log)
+
+    return {
+        ...base,
+        headline: formatted.headline,
+        chips: formatted.chips || [],
+        diffs: formatted.diffs || [],
+        summary: formatted.summary || formatted.headline,
+    }
+}
+
+export { formatDate, formatTime, formatDateTime, formatDateRange, formatMonthLabel, formatHours }

--- a/src/utils/auditFormatting.test.js
+++ b/src/utils/auditFormatting.test.js
@@ -1,0 +1,403 @@
+import { describe, it, expect } from 'vitest'
+import {
+    ACTION_CATALOG,
+    ACTION_ALIASES,
+    normalizeActionKey,
+    getCatalogEntry,
+    formatValue,
+    formatAuditEntry,
+} from './auditFormatting'
+
+describe('normalizeActionKey', () => {
+    it('returns canonical key for known aliases', () => {
+        expect(normalizeActionKey('absence_approved')).toBe('absence_genehmigt')
+        expect(normalizeActionKey('absence_rejected')).toBe('absence_abgelehnt')
+        expect(normalizeActionKey('urlaub_genehmigt')).toBe('absence_genehmigt')
+        expect(normalizeActionKey('bericht_genehmigt')).toBe('approve_report')
+        expect(normalizeActionKey('employee_deactivated')).toBe('deactivate_user')
+        expect(normalizeActionKey('krankmeldung')).toBe('sick_report_created')
+    })
+
+    it('returns input unchanged for canonical keys', () => {
+        expect(normalizeActionKey('shift_created')).toBe('shift_created')
+        expect(normalizeActionKey('approve_report')).toBe('approve_report')
+    })
+
+    it('returns null for falsy input', () => {
+        expect(normalizeActionKey(null)).toBe(null)
+        expect(normalizeActionKey(undefined)).toBe(null)
+        expect(normalizeActionKey('')).toBe(null)
+    })
+
+    it('all aliases resolve to catalog entries', () => {
+        for (const alias of Object.keys(ACTION_ALIASES)) {
+            const key = normalizeActionKey(alias)
+            expect(ACTION_CATALOG[key], `alias ${alias} -> ${key}`).toBeDefined()
+        }
+    })
+})
+
+describe('getCatalogEntry', () => {
+    it('returns entry for canonical action', () => {
+        const entry = getCatalogEntry('shift_created')
+        expect(entry.label).toBe('Schicht erstellt')
+        expect(entry.category).toBe('shifts')
+    })
+
+    it('resolves alias before lookup', () => {
+        const entry = getCatalogEntry('absence_approved')
+        expect(entry.label).toBe('Urlaub genehmigt')
+    })
+
+    it('returns null for unknown action', () => {
+        expect(getCatalogEntry('totally_unknown')).toBe(null)
+    })
+})
+
+describe('formatValue', () => {
+    it('translates status values to German', () => {
+        expect(formatValue('status', 'pending')).toBe('Ausstehend')
+        expect(formatValue('status', 'approved')).toBe('Genehmigt')
+        expect(formatValue('status', 'rejected')).toBe('Abgelehnt')
+        expect(formatValue('status', 'genehmigt')).toBe('Genehmigt')
+    })
+
+    it('translates role values to German', () => {
+        expect(formatValue('role', 'admin')).toBe('Administrator')
+        expect(formatValue('role', 'employee')).toBe('Mitarbeiter')
+    })
+
+    it('formats is_active as Ja/Nein', () => {
+        expect(formatValue('is_active', true)).toBe('Ja')
+        expect(formatValue('is_active', false)).toBe('Nein')
+    })
+
+    it('formats shift type codes to full names', () => {
+        expect(formatValue('type', 'ND')).toBe('Nachtdienst')
+        expect(formatValue('type', 'TD1')).toBe('Tagdienst 1')
+        expect(formatValue('type', 'AST')).toBe('Anlaufstelle')
+    })
+
+    it('formats absence type passthrough', () => {
+        expect(formatValue('type', 'Urlaub')).toBe('Urlaub')
+        expect(formatValue('type', 'Krank')).toBe('Krankmeldung')
+    })
+
+    it('formats date fields as German date', () => {
+        expect(formatValue('start_date', '2026-04-15')).toBe('15.04.2026')
+        expect(formatValue('end_date', '2026-12-01')).toBe('01.12.2026')
+    })
+
+    it('formats time fields as HH:mm', () => {
+        expect(formatValue('start_time', '2026-04-15T07:30:00Z')).toMatch(/^\d{2}:\d{2}$/)
+    })
+
+    it('formats weekly_hours with unit', () => {
+        expect(formatValue('weekly_hours', 40)).toBe('40 h')
+    })
+
+    it('formats correction_hours with sign', () => {
+        expect(formatValue('correction_hours', 4.5)).toBe('+4,5 h')
+        expect(formatValue('correction_hours', -2)).toBe('-2,0 h')
+    })
+
+    it('formats vacation_days with unit', () => {
+        expect(formatValue('vacation_days_per_year', 25)).toBe('25 Tage')
+    })
+
+    it('handles null/undefined gracefully', () => {
+        expect(formatValue('anything', null)).toBe('—')
+        expect(formatValue('anything', undefined)).toBe('—')
+        expect(formatValue('anything', '')).toBe('—')
+    })
+})
+
+describe('formatAuditEntry — shift actions', () => {
+    it('shift_created: shows type + date + time', () => {
+        const log = {
+            action: 'shift_created',
+            changes: { date: '2026-04-15', type: 'ND', start_time: '2026-04-15T22:00:00Z', end_time: '2026-04-16T06:00:00Z' },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.label).toBe('Schicht erstellt')
+        expect(r.category).toBe('shifts')
+        expect(r.headline).toContain('Nachtdienst')
+        expect(r.headline).toContain('15.04.2026')
+    })
+
+    it('shift_updated: returns before/after diffs', () => {
+        const log = {
+            action: 'shift_updated',
+            changes: {
+                before: { start_time: '2026-04-15T22:00:00Z', end_time: '2026-04-16T06:00:00Z', type: 'ND' },
+                after: { start_time: '2026-04-15T23:00:00Z', end_time: '2026-04-16T07:00:00Z', type: 'ND' },
+            },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('bearbeitet')
+        expect(r.diffs.length).toBe(2)
+        expect(r.diffs.find(d => d.field === 'start_time')).toBeDefined()
+    })
+
+    it('shift_deleted: shows deleted shift info', () => {
+        const log = {
+            action: 'shift_deleted',
+            changes: { deleted: { type: 'AST', start_time: '2026-04-12T09:00:00Z' } },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('Anlaufstelle')
+        expect(r.headline).toContain('gelöscht')
+    })
+
+    it('generate_roster: shows month + stats chips', () => {
+        const log = {
+            action: 'generate_roster',
+            metadata: { month: '2026-03', created: 20, skipped: 2 },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('März 2026')
+        expect(r.headline).toContain('generiert')
+        expect(r.chips.some(c => c.label === '20 erstellt')).toBe(true)
+        expect(r.chips.some(c => c.label === '2 übersprungen')).toBe(true)
+    })
+
+    it('replace_roster: shows deleted + created chips', () => {
+        const log = {
+            action: 'replace_roster',
+            metadata: { month: '2026-05', created: 23, deleted: 5 },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('Mai 2026')
+        expect(r.headline).toContain('ersetzt')
+        expect(r.chips.some(c => c.label === '23 erstellt')).toBe(true)
+        expect(r.chips.some(c => c.label === '5 gelöscht')).toBe(true)
+    })
+})
+
+describe('formatAuditEntry — absence actions', () => {
+    it('absence_genehmigt: shows date range + status diff', () => {
+        const log = {
+            action: 'absence_genehmigt',
+            changes: {
+                before: { status: 'pending' },
+                after: { status: 'genehmigt' },
+                context: { type: 'Urlaub', start_date: '2026-04-12', end_date: '2026-04-15' },
+            },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('Urlaub')
+        expect(r.headline).toContain('12.04.2026')
+        expect(r.headline).toContain('15.04.2026')
+        expect(r.headline).toContain('genehmigt')
+        expect(r.diffs[0].before).toBe('Ausstehend')
+        expect(r.diffs[0].after).toBe('Genehmigt')
+    })
+
+    it('absence_approved (alias) resolves to same formatter', () => {
+        const log = {
+            action: 'absence_approved',
+            changes: {
+                before: { status: 'pending' },
+                after: { status: 'approved' },
+                context: { type: 'Urlaub', start_date: '2026-04-12', end_date: '2026-04-15' },
+            },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.actionKey).toBe('absence_genehmigt')
+        expect(r.label).toBe('Urlaub genehmigt')
+    })
+
+    it('absence_storniert: shows storniert verb', () => {
+        const log = {
+            action: 'absence_storniert',
+            changes: {
+                before: { status: 'genehmigt' },
+                after: { status: 'storniert' },
+                context: { type: 'Urlaub', start_date: '2026-04-12', end_date: '2026-04-15' },
+            },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('storniert')
+    })
+
+    it('sick_report_created: shows range + hours + affected shifts', () => {
+        const log = {
+            action: 'sick_report_created',
+            changes: {
+                after: {
+                    start_date: '2026-04-12',
+                    end_date: '2026-04-15',
+                    type: 'Krank',
+                    planned_hours: 24,
+                    affected_shifts: ['s1', 's2', 's3'],
+                },
+            },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('Krankmeldung')
+        expect(r.headline).toContain('24 h')
+        expect(r.headline).toContain('3 Schichten')
+    })
+
+    it('sick_leave_deleted: shows range + reason', () => {
+        const log = {
+            action: 'sick_leave_deleted',
+            changes: { before: { start_date: '2026-04-12', end_date: '2026-04-15' } },
+            metadata: { reason: 'Versehentlich erfasst' },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('gelöscht')
+        expect(r.diffs.some(d => d.fieldLabel === 'Grund')).toBe(true)
+    })
+
+    it('sick_leave_shortened: shows end_date diff', () => {
+        const log = {
+            action: 'sick_leave_shortened',
+            changes: {
+                before: { start_date: '2026-04-12', end_date: '2026-04-15' },
+                after: { end_date: '2026-04-13' },
+            },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('gekürzt')
+        expect(r.diffs.find(d => d.field === 'end_date').before).toBe('15.04.2026')
+        expect(r.diffs.find(d => d.field === 'end_date').after).toBe('13.04.2026')
+    })
+})
+
+describe('formatAuditEntry — report actions', () => {
+    it('approve_report: shows month + status diff', () => {
+        const log = {
+            action: 'approve_report',
+            changes: { before: { status: 'submitted' }, after: { status: 'genehmigt' } },
+            metadata: { year: 2026, month: 3 },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('März 2026')
+        expect(r.headline).toContain('genehmigt')
+    })
+
+    it('reject_report: shows month + abgelehnt', () => {
+        const log = {
+            action: 'reject_report',
+            changes: { before: { status: 'submitted' }, after: { status: 'abgelehnt' } },
+            metadata: { year: 2026, month: 4 },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('April 2026')
+        expect(r.headline).toContain('abgelehnt')
+    })
+
+    it('time_entry_approved: shows diffs', () => {
+        const log = {
+            action: 'time_entry_approved',
+            changes: {
+                before: { start_time: '2026-04-12T07:00:00Z' },
+                after: { start_time: '2026-04-12T07:15:00Z' },
+            },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('Zeiteintrag')
+        expect(r.diffs.length).toBe(1)
+    })
+})
+
+describe('formatAuditEntry — correction actions', () => {
+    it('create_correction: shows hours + month + reason diff', () => {
+        const log = {
+            action: 'create_correction',
+            changes: { correction_hours: 4.5, previous_total: 10, target_total: 14.5, reason: 'Ausgleich' },
+            metadata: { month: '2026-03' },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('Saldo-Korrektur')
+        expect(r.headline).toContain('+4,5 h')
+        expect(r.headline).toContain('März 2026')
+        expect(r.diffs.some(d => d.fieldLabel === 'Saldo')).toBe(true)
+        expect(r.diffs.some(d => d.fieldLabel === 'Grund')).toBe(true)
+    })
+
+    it('balance_correction_deleted: shows hours', () => {
+        const log = {
+            action: 'balance_correction_deleted',
+            changes: { before: { correction_hours: -2, reason: 'Falsch eingetragen' } },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('gelöscht')
+        expect(r.headline).toContain('-2,0 h')
+    })
+})
+
+describe('formatAuditEntry — employee actions', () => {
+    it('employee_created: shows name + key fields', () => {
+        const log = {
+            action: 'employee_created',
+            changes: {
+                after: {
+                    full_name: 'Anna Muster',
+                    email: 'anna@example.com',
+                    role: 'employee',
+                    weekly_hours: 40,
+                    vacation_days_per_year: 25,
+                    initial_balance: 0,
+                },
+            },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.headline).toContain('Anna Muster')
+        expect(r.headline).toContain('angelegt')
+        expect(r.diffs.find(d => d.field === 'email').after).toBe('anna@example.com')
+        expect(r.diffs.find(d => d.field === 'role').after).toBe('Mitarbeiter')
+        expect(r.diffs.find(d => d.field === 'weekly_hours').after).toBe('40 h')
+        expect(r.diffs.find(d => d.field === 'vacation_days_per_year').after).toBe('25 Tage')
+    })
+
+    it('employee_updated: returns diffs', () => {
+        const log = {
+            action: 'employee_updated',
+            changes: {
+                before: { weekly_hours: 40, vacation_days_per_year: 25 },
+                after: { weekly_hours: 30, vacation_days_per_year: 25 },
+            },
+        }
+        const r = formatAuditEntry(log)
+        expect(r.diffs.length).toBe(1)
+        expect(r.diffs[0].field).toBe('weekly_hours')
+        expect(r.diffs[0].before).toBe('40 h')
+        expect(r.diffs[0].after).toBe('30 h')
+    })
+
+    it('deactivate_user: simple headline', () => {
+        const r = formatAuditEntry({ action: 'deactivate_user' })
+        expect(r.headline).toBe('Mitarbeiter deaktiviert')
+    })
+
+    it('reactivate_user: simple headline', () => {
+        const r = formatAuditEntry({ action: 'reactivate_user' })
+        expect(r.headline).toBe('Mitarbeiter reaktiviert')
+    })
+})
+
+describe('formatAuditEntry — robustness', () => {
+    it('handles unknown action gracefully', () => {
+        const r = formatAuditEntry({ action: 'foo_bar_unknown' })
+        expect(r.actionKey).toBe('foo_bar_unknown')
+        expect(r.label).toBe('foo_bar_unknown')
+        expect(r.category).toBe('other')
+    })
+
+    it('handles missing changes/metadata', () => {
+        const r = formatAuditEntry({ action: 'shift_created' })
+        expect(r).toBeDefined()
+        expect(r.diffs).toEqual([])
+    })
+
+    it('every catalog action has a catalog entry with label, category, color, icon', () => {
+        for (const [key, entry] of Object.entries(ACTION_CATALOG)) {
+            expect(entry.label, `${key} label`).toBeTruthy()
+            expect(entry.category, `${key} category`).toBeTruthy()
+            expect(entry.color, `${key} color`).toBeTruthy()
+            expect(entry.icon, `${key} icon`).toBeTruthy()
+        }
+    })
+})


### PR DESCRIPTION
## Summary

- Neues Utility `src/utils/auditFormatting.js` mit zentralem `ACTION_CATALOG` (20 action-types), `ACTION_ALIASES` für Legacy-Namen, und `formatAuditEntry()` als Haupt-Formatter — inkl. 41 Unit-Tests
- `AdminAuditLog.jsx` komplett überarbeitet: deutsche Labels, Such-Input, 5 Filter-Dimensionen, Tages-Gruppierung, neue Karten mit Icon + Vorher/Nachher-Diff + expandierbaren Rohdaten
- CSV-Export nutzt jetzt kompakte Zusammenfassungen statt JSON-Dumps

## Motivation

Der Audit-Tab zeigte bisher:
- englische Feldnamen (`weekly_hours`, `start_time`, `is_active`)
- unübersetzte Status-Werte (`pending → approved`)
- JSON-Dumps bei unbekannten Formaten
- 4 action-types ohne UI-Badge (`generate_roster`, `replace_roster`, `sick_leave_deleted`, `sick_leave_shortened`)
- Header/Buttons teils englisch

Jetzt liest sich jede der 20 Aktionsarten wie ein vollständiger deutscher Satz, z.B. "Nachtdienst am 15.04.2026 bearbeitet", "Monatsbericht März 2026 genehmigt", "Dienstplan für März 2026 generiert".

Rohdaten sind per Klick pro Karte einsehbar.

fixes #167

## Test plan

- [x] `npm run build` — ok
- [x] `npm test` — 694/694 grün (41 neu)
- [x] `npm run lint` — keine neuen Fehler
- [ ] Manuell: Admin → Dashboard → Audit-Tab, alle Filter durchprobieren
- [ ] Manuell: Bei mindestens einer Karte jeder Kategorie "Rohdaten anzeigen" prüfen
- [ ] Manuell: CSV-Export öffnen, Zusammenfassungs-Spalte sinnvoll
- [ ] Manuell: Mobile-Ansicht (Diff-Box, Header)

## Out of scope

- Konsolidierung der Schreib-Seite (legacy action-type-Namen in `adminAudit.js` / Aufrufern) — die UI toleriert beide Varianten via `ACTION_ALIASES`
- Schema-Änderungen
- Fehlende `before`-Daten bei `shift_updated` → separates Issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded audit log filtering capabilities: filter by category, specific action, affected employee, and free-text search.
  * Audit entries now grouped by day with improved visual presentation including icons and color-coded categories.
  * Added expandable raw data view for detailed audit entry inspection.
  * Updated CSV export with German naming convention.

* **Tests**
  * Added comprehensive test coverage for audit formatting utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->