### PR TITLE
feat: Admin-Badge in Tab-Teilbadges aufschlüsseln (Anträge + Krank) (#169)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import OfflineIndicator from './components/OfflineIndicator'
 import ReloadPrompt from './components/ReloadPrompt'
 import { supabase } from './supabase'
 import { debounce } from './utils/debounce'
+import { useAdminBadgeCounts } from './utils/useAdminBadgeCounts'
 
 // Lazy load heavy components for better initial load time
 const AbsencePlanner = lazy(() => import('./components/AbsencePlanner'))
@@ -40,54 +41,46 @@ function AppContent() {
   const { user, isAdmin, isViewer, passwordSet, refreshPasswordSet } = useAuth()
   const [activeTab, setActiveTab] = useState('roster')
   const [calendarDate, setCalendarDate] = useState(null)
-  const [badges, setBadges] = useState({})
+  const [urgentShiftsDot, setUrgentShiftsDot] = useState(false)
   const [openCoverageCount, setOpenCoverageCount] = useState(0)
 
-  // Fetch badge counts for navigation
+  const { total: adminBadgeCount } = useAdminBadgeCounts(user?.id, isAdmin)
+
+  const badges = {
+    admin: adminBadgeCount > 0 ? { count: adminBadgeCount } : null,
+    roster: urgentShiftsDot ? { dot: true } : null,
+  }
+
+  // Track urgent shifts as a dot on the roster tab (separate from admin badge)
   useEffect(() => {
     if (!user || !isAdmin) {
-      setBadges({})
+      setUrgentShiftsDot(false)
       return
     }
 
-    const fetchBadgeCounts = async () => {
+    const fetchUrgent = async () => {
       try {
-        // Count pending absence requests
-        const { count: pendingAbsences } = await supabase
-          .from('absences')
-          .select('*', { count: 'exact', head: true })
-          .eq('status', 'beantragt')
-
-        // Count urgent shifts (shifts with urgent_since set)
-        const { count: urgentShifts } = await supabase
+        const { count } = await supabase
           .from('shifts')
           .select('*', { count: 'exact', head: true })
           .not('urgent_since', 'is', null)
-
-        const adminCount = (pendingAbsences || 0) + (urgentShifts || 0)
-
-        setBadges({
-          admin: adminCount > 0 ? { count: adminCount } : null,
-          roster: urgentShifts > 0 ? { dot: true } : null
-        })
+        setUrgentShiftsDot((count || 0) > 0)
       } catch (err) {
-        console.error('Failed to fetch badge counts:', err)
+        console.error('Failed to fetch urgent shifts count:', err)
       }
     }
 
-    fetchBadgeCounts()
+    fetchUrgent()
 
-    // Subscribe to realtime updates (debounced to avoid cascade fetches)
-    const debouncedBadgeFetch = debounce(fetchBadgeCounts, 1000)
-    let badgeWasConnected = false
+    const debouncedFetch = debounce(fetchUrgent, 1000)
+    let wasConnected = false
     const channel = supabase
-      .channel('badge-updates')
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'absences' }, debouncedBadgeFetch)
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'shifts' }, debouncedBadgeFetch)
+      .channel('roster-urgent-dot')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'shifts' }, debouncedFetch)
       .subscribe((status) => {
         if (status === 'SUBSCRIBED') {
-          if (badgeWasConnected) fetchBadgeCounts()
-          badgeWasConnected = true
+          if (wasConnected) fetchUrgent()
+          wasConnected = true
         }
       })
 

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -8,17 +8,34 @@ import AdminEmployees from './admin/AdminEmployees'
 import AdminAbsences from './admin/AdminAbsences'
 import AdminVacationStats from './admin/AdminVacationStats'
 import AdminRosterPlanner from './admin/AdminRosterPlanner'
+import Badge from './Badge'
+import { useAuth } from '../AuthContext'
+import { useAdminBadgeCounts } from '../utils/useAdminBadgeCounts'
 
 export default function AdminDashboard(props) {
+    const { user, isAdmin } = useAuth()
     const [activeTab, setActiveTab] = useState(() => {
         const saved = sessionStorage.getItem('adminDashTab')
         return saved === 'calendar' ? 'overview' : (saved || 'overview')
     })
 
+    const { antraege, krank, markKrankSeen } = useAdminBadgeCounts(user?.id, isAdmin)
+
     const handleTabChange = (tab) => {
         sessionStorage.setItem('adminDashTab', tab)
         setActiveTab(tab)
+        if (tab === 'sick') markKrankSeen()
     }
+
+    const tabs = [
+        { id: 'planner', icon: CalendarDays, label: 'Dienstplan' },
+        { id: 'audit', icon: ShieldCheck, label: 'Audit' },
+        { id: 'employees', icon: Users, label: 'Mitarbeiter' },
+        { id: 'absences', icon: FileText, label: 'Anträge', badgeCount: antraege },
+        { id: 'sick', icon: Thermometer, label: 'Krank', badgeCount: krank },
+        { id: 'vacation', icon: Palmtree, label: 'Urlaub' },
+        { id: 'overview', icon: BarChart3, label: 'Übersicht' },
+    ]
 
     return (
         <div className="p-4 pb-24 max-w-xl md:max-w-3xl lg:max-w-5xl mx-auto">
@@ -26,27 +43,16 @@ export default function AdminDashboard(props) {
 
             {/* Navigation Tabs */}
             <div className="flex flex-wrap gap-2 mb-6 px-2">
-                <button onClick={() => handleTabChange('planner')} className={`flex-1 min-w-[100px] flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl text-sm font-bold transition-all ${activeTab === 'planner' ? 'bg-teal-500 text-white shadow-md' : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'}`}>
-                    <CalendarDays size={16} /> Dienstplan
-                </button>
-                <button onClick={() => handleTabChange('audit')} className={`flex-1 min-w-[100px] flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl text-sm font-bold transition-all ${activeTab === 'audit' ? 'bg-teal-500 text-white shadow-md' : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'}`}>
-                    <ShieldCheck size={16} /> Audit
-                </button>
-                <button onClick={() => handleTabChange('employees')} className={`flex-1 min-w-[100px] flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl text-sm font-bold transition-all ${activeTab === 'employees' ? 'bg-teal-500 text-white shadow-md' : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'}`}>
-                    <Users size={16} /> Mitarbeiter
-                </button>
-                <button onClick={() => handleTabChange('absences')} className={`flex-1 min-w-[100px] flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl text-sm font-bold transition-all ${activeTab === 'absences' ? 'bg-teal-500 text-white shadow-md' : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'}`}>
-                    <FileText size={16} /> Anträge
-                </button>
-                <button onClick={() => handleTabChange('sick')} className={`flex-1 min-w-[100px] flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl text-sm font-bold transition-all ${activeTab === 'sick' ? 'bg-teal-500 text-white shadow-md' : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'}`}>
-                    <Thermometer size={16} /> Krank
-                </button>
-                <button onClick={() => handleTabChange('vacation')} className={`flex-1 min-w-[100px] flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl text-sm font-bold transition-all ${activeTab === 'vacation' ? 'bg-teal-500 text-white shadow-md' : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'}`}>
-                    <Palmtree size={16} /> Urlaub
-                </button>
-                <button onClick={() => handleTabChange('overview')} className={`flex-1 min-w-[100px] flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl text-sm font-bold transition-all ${activeTab === 'overview' ? 'bg-teal-500 text-white shadow-md' : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'}`}>
-                    <BarChart3 size={16} /> Übersicht
-                </button>
+                {tabs.map(({ id, icon: Icon, label, badgeCount }) => (
+                    <button
+                        key={id}
+                        onClick={() => handleTabChange(id)}
+                        className={`flex-1 min-w-[100px] flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl text-sm font-bold transition-all ${activeTab === id ? 'bg-teal-500 text-white shadow-md' : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'}`}
+                    >
+                        <Icon size={16} /> {label}
+                        <Badge count={badgeCount} />
+                    </button>
+                ))}
             </div>
 
             {/* Content Container */}

--- a/src/components/AdminDashboard.test.jsx
+++ b/src/components/AdminDashboard.test.jsx
@@ -6,6 +6,14 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import AdminDashboard from './AdminDashboard'
 
+// Mock auth + badge hook so the component renders without a real AuthProvider
+vi.mock('../AuthContext', () => ({
+    useAuth: () => ({ user: { id: 'test-admin' }, isAdmin: true })
+}))
+vi.mock('../utils/useAdminBadgeCounts', () => ({
+    useAdminBadgeCounts: () => ({ antraege: 0, krank: 0, total: 0, markKrankSeen: vi.fn() })
+}))
+
 // Mock all admin sub-panels to isolate tab navigation logic
 vi.mock('./admin/AdminOverview', () => ({
     default: () => <div data-testid="admin-overview">AdminOverview</div>

--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -1,0 +1,24 @@
+export default function Badge({ count, dot = false, floating = false }) {
+    if (!count && !dot) return null
+
+    if (floating) {
+        if (dot) {
+            return <span className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 bg-red-500 rounded-full border-2 border-white" />
+        }
+        return (
+            <span className="absolute -top-1 -right-2 min-w-[18px] h-[18px] bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center border-2 border-white">
+                {count > 99 ? '99+' : count}
+            </span>
+        )
+    }
+
+    if (dot) {
+        return <span className="w-2 h-2 bg-red-500 rounded-full" />
+    }
+
+    return (
+        <span className="min-w-[20px] h-5 bg-red-500 text-white text-xs font-bold rounded-full flex items-center justify-center px-1">
+            {count > 99 ? '99+' : count}
+        </span>
+    )
+}

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -1,21 +1,5 @@
 import { Calendar, List, User, Plane, Shield } from 'lucide-react'
-
-// Badge component for notification dots
-function Badge({ count, dot = false }) {
-    if (!count && !dot) return null
-
-    if (dot) {
-        return (
-            <span className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 bg-red-500 rounded-full border-2 border-white" />
-        )
-    }
-
-    return (
-        <span className="absolute -top-1 -right-2 min-w-[18px] h-[18px] bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center border-2 border-white">
-            {count > 99 ? '99+' : count}
-        </span>
-    )
-}
+import Badge from './Badge'
 
 // NavItem component for cleaner code
 function NavItem({ id, icon: Icon, label, isActive, onClick, badge }) {
@@ -26,7 +10,7 @@ function NavItem({ id, icon: Icon, label, isActive, onClick, badge }) {
         >
             <div className="relative">
                 <Icon size={24} />
-                <Badge count={badge?.count} dot={badge?.dot} />
+                <Badge count={badge?.count} dot={badge?.dot} floating />
             </div>
             <span className="text-[10px] font-medium mt-1">{label}</span>
         </button>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,21 +1,5 @@
 import { Calendar, List, User, Plane, Shield } from 'lucide-react'
-
-// Badge component matching BottomNav
-function Badge({ count, dot = false }) {
-    if (!count && !dot) return null
-
-    if (dot) {
-        return (
-            <span className="w-2 h-2 bg-red-500 rounded-full" />
-        )
-    }
-
-    return (
-        <span className="min-w-[20px] h-5 bg-red-500 text-white text-xs font-bold rounded-full flex items-center justify-center px-1">
-            {count > 99 ? '99+' : count}
-        </span>
-    )
-}
+import Badge from './Badge'
 
 export default function Sidebar({ activeTab, onTabChange, isAdmin, isViewer, badges = {} }) {
     const navItems = [

--- a/src/utils/useAdminBadgeCounts.js
+++ b/src/utils/useAdminBadgeCounts.js
@@ -1,0 +1,100 @@
+import { useState, useEffect, useCallback } from 'react'
+import { supabase } from '../supabase'
+import { debounce } from './debounce'
+
+const SICK_SEEN_KEY_PREFIX = 'admin_sick_last_seen_'
+const SICK_SEEN_EVENT = 'admin-sick-seen'
+
+function readLastSeen(userId) {
+    if (!userId) return null
+    try {
+        return localStorage.getItem(SICK_SEEN_KEY_PREFIX + userId)
+    } catch {
+        return null
+    }
+}
+
+export function markAdminKrankSeen(userId) {
+    if (!userId) return
+    try {
+        localStorage.setItem(SICK_SEEN_KEY_PREFIX + userId, new Date().toISOString())
+        window.dispatchEvent(new CustomEvent(SICK_SEEN_EVENT))
+    } catch {
+        // localStorage disabled — silent fallback
+    }
+}
+
+export function useAdminBadgeCounts(userId, isAdmin) {
+    const [counts, setCounts] = useState({ antraege: 0, krank: 0 })
+
+    const fetchCounts = useCallback(async () => {
+        if (!userId || !isAdmin) {
+            setCounts({ antraege: 0, krank: 0 })
+            return
+        }
+        try {
+            const lastSeen = readLastSeen(userId)
+
+            const antraegeQuery = supabase
+                .from('absences')
+                .select('*', { count: 'exact', head: true })
+                .eq('status', 'beantragt')
+                .neq('type', 'Krank')
+
+            let krankQuery = supabase
+                .from('absences')
+                .select('*', { count: 'exact', head: true })
+                .in('type', ['Krank', 'Krankenstand'])
+            if (lastSeen) krankQuery = krankQuery.gt('created_at', lastSeen)
+
+            const [antraegeRes, krankRes] = await Promise.all([antraegeQuery, krankQuery])
+
+            setCounts({
+                antraege: antraegeRes.count || 0,
+                krank: krankRes.count || 0,
+            })
+        } catch (err) {
+            console.error('useAdminBadgeCounts fetch failed:', err)
+        }
+    }, [userId, isAdmin])
+
+    useEffect(() => {
+        if (!userId || !isAdmin) {
+            setCounts({ antraege: 0, krank: 0 })
+            return
+        }
+
+        fetchCounts()
+
+        const debouncedFetch = debounce(fetchCounts, 1000)
+        let wasConnected = false
+        const channel = supabase
+            .channel('admin-badge-counts')
+            .on('postgres_changes', { event: '*', schema: 'public', table: 'absences' }, debouncedFetch)
+            .subscribe((status) => {
+                if (status === 'SUBSCRIBED') {
+                    if (wasConnected) fetchCounts()
+                    wasConnected = true
+                }
+            })
+
+        const onSeen = () => fetchCounts()
+        window.addEventListener(SICK_SEEN_EVENT, onSeen)
+
+        return () => {
+            supabase.removeChannel(channel)
+            window.removeEventListener(SICK_SEEN_EVENT, onSeen)
+        }
+    }, [userId, isAdmin, fetchCounts])
+
+    const markKrankSeen = useCallback(() => {
+        markAdminKrankSeen(userId)
+    }, [userId])
+
+    return {
+        antraege: counts.antraege,
+        krank: counts.krank,
+        total: counts.antraege + counts.krank,
+        markKrankSeen,
+    }
+}


### PR DESCRIPTION
fixes #169

## Summary

- Admin sieht beim Öffnen des Admin-Dashboards jetzt eine rote Zahl-Badge direkt auf dem **Anträge**-Tab und auf dem **Krank**-Tab. Summe = Haupt-Admin-Badge.
- **Anträge**-Badge: offene Urlaubsanträge (`status='beantragt'`, ohne Krank), verschwindet bei Genehmigen/Ablehnen.
- **Krank**-Badge: neue/ungesehene Krankmeldungen. Pro Admin-User via `localStorage`-Timestamp getrackt. Badge räumt sich auf, sobald der Admin den Krank-Tab öffnet.
- **Haupt-Admin-Badge**: zählt jetzt `offene Anträge + ungesehene Krankmeldungen`. Urgent-Shifts mischen nicht mehr in die Admin-Zahl, bleiben aber als Dot auf dem Roster-Tab sichtbar.
- Neuer Hook `useAdminBadgeCounts` als Single Source of Truth für `App.jsx` + `AdminDashboard.jsx`.
- Badge-Komponente aus `BottomNav` nach `src/components/Badge.jsx` extrahiert — Sidebar und AdminDashboard nutzen dieselbe Komponente (mit `floating`-Prop für absolute Positionierung).

## Test plan

- [ ] Als Mitarbeiter 2 Urlaubsanträge stellen → als Admin einloggen → Haupt-Badge zeigt 2, Anträge-Tab zeigt 2. Einen genehmigen → beide zeigen 1.
- [ ] Als Mitarbeiter krankmelden → Haupt-Badge +1, Krank-Tab zeigt Zahl. Admin klickt Krank-Tab → beide verschwinden. Seite reload → bleiben weg. Neue Krankmeldung → Badge erscheint wieder.
- [ ] Kombi: 2 Anträge + 2 neue Krankmeldungen → Haupt-Badge = 4, Anträge = 2, Krank = 2.
- [ ] Realtime: Dashboard offen lassen, aus zweitem Fenster Antrag anlegen → Badge aktualisiert sich innerhalb ~1s ohne Reload.
- [ ] Desktop (Sidebar) und Mobile (BottomNav) sehen optisch unverändert aus.
- [ ] `npm run build` ✅, `npm test` ✅ (694 Tests grün), `npm run lint` ✅ (keine neuen Warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicators for urgent shifts in admin navigation
  * Introduced dedicated badge component for consistent count display across the app

* **Improvements**
  * Enhanced real-time updates for absence request and sick leave counts
  * Added ability to mark sick leave items as viewed
  * Improved badge styling and presentation consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->