### PR TITLE
fix: Admin-Dashboard Realtime-Channel-Collision (#171)

### DIFF
--- a/src/utils/useAdminBadgeCounts.js
+++ b/src/utils/useAdminBadgeCounts.js
@@ -68,8 +68,9 @@ export function useAdminBadgeCounts(userId, isAdmin) {
 
         const debouncedFetch = debounce(fetchCounts, 1000)
         let wasConnected = false
+        const channelName = `admin-badge-counts-${Math.random().toString(36).slice(2, 10)}`
         const channel = supabase
-            .channel('admin-badge-counts')
+            .channel(channelName)
             .on('postgres_changes', { event: '*', schema: 'public', table: 'absences' }, debouncedFetch)
             .subscribe((status) => {
                 if (status === 'SUBSCRIBED') {


### PR DESCRIPTION
fixes #171

## Summary

Admin-Dashboard crashte auf Production mit:
```
Error: cannot add `postgres_changes` callbacks for realtime:admin-badge-counts after `subscribe()`.
```

Der Hook `useAdminBadgeCounts` (aus #170) wird in `App.jsx` und `AdminDashboard.jsx` parallel gemountet — beide Instanzen versuchten, denselben Supabase-Channel `admin-badge-counts` zu abonnieren.

## Fix

Channel-Name pro Hook-Instanz mit Random-Suffix:
```js
const channelName = `admin-badge-counts-${Math.random().toString(36).slice(2, 10)}`
```

## Test plan

- [ ] Preview-Deployment öffnen, als Admin einloggen
- [ ] Admin-Dashboard klicken → keine Crash-Seite, Tab-Badges rendern
- [ ] Browser-Console: keine Supabase-Realtime-Fehler
- [ ] `npm run build` ✅, `npm test` ✅ (694 Tests grün)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of real-time admin badge count updates to prevent potential conflicts when multiple subscriptions are active simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->