### PR TITLE
fix: Push-Nachricht zeigt korrekte Dienstanzahl bei Krankmeldung (#173)

### DIFF
--- a/supabase/functions/notify-sickness/index.ts
+++ b/supabase/functions/notify-sickness/index.ts
@@ -233,11 +233,9 @@ serve(async (req) => {
         const totalFlex = Object.values(flexCounts).reduce((sum: number, c: number) => sum + c, 0)
         const teamAvgFlex = coverageEligibleUserIds.length > 0 ? (totalFlex / coverageEligibleUserIds.length).toFixed(1) : '0'
 
-        // Determine shift type text for push — use snapshot (deterministic), not urgent_since query (race with frontend RPC).
-        const SHIFT_NAMES: Record<string, string> = { TD1: 'TD1', TD2: 'TD2', ND: 'Nachtdienst', DBD: 'DBD' }
-        const shiftTypeText = snapshotShifts.length === 1
-            ? (SHIFT_NAMES[snapshotShifts[0].type] || snapshotShifts[0].type)
-            : `${snapshotShifts.length} Dienste`
+        // Determine shift type text for push — list unique types (e.g. "TD1 + ND"), short form.
+        const uniqueTypes = [...new Set(snapshotShifts.map((s: any) => s.type))]
+        const shiftTypeText = uniqueTypes.join(' + ')
 
         if (!subscriptions?.length) {
             console.log("No subscriptions found to notify.")

--- a/supabase/functions/notify-sickness/index.ts
+++ b/supabase/functions/notify-sickness/index.ts
@@ -95,12 +95,6 @@ serve(async (req) => {
         // Check if we are crashing before even starting
         console.log("Function invoked - v2.0")
 
-        // NEW: Sleep for 2000ms to avoid a race condition.
-        // The frontend inserts the absence (triggering this webhook) and THEN executes
-        // the mark_shifts_urgent RPC. We must wait for the RPC to commit so we can find the urgent shifts.
-        console.log("Waiting 2s for frontend RPCs to commit...")
-        await new Promise(r => setTimeout(r, 2000))
-
         const supabaseClient = createClient(
             Deno.env.get('SUPABASE_URL') ?? '',
             Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
@@ -121,6 +115,16 @@ serve(async (req) => {
         if (record.type !== 'Krank' && record.type !== 'Krankenstand') {
             console.log("Ignored: Type is not Sick")
             return new Response(JSON.stringify({ message: 'Ignored: Type' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+        }
+
+        // Read shifts to cover directly from the absence snapshot — deterministic, no race with mark_shifts_urgent.
+        // Filter matches RosterFeed.jsx: TEAM/FORTBILDUNG need no coverage.
+        const snapshotShifts = (record.planned_shifts_snapshot || [])
+            .filter((s: any) => s && s.type !== 'TEAM' && s.type !== 'FORTBILDUNG')
+
+        if (snapshotShifts.length === 0) {
+            console.log("No shifts to cover — skipping push.")
+            return new Response(JSON.stringify({ message: 'No shifts to cover' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
         }
 
         const sickUserId = record.user_id
@@ -229,11 +233,11 @@ serve(async (req) => {
         const totalFlex = Object.values(flexCounts).reduce((sum: number, c: number) => sum + c, 0)
         const teamAvgFlex = coverageEligibleUserIds.length > 0 ? (totalFlex / coverageEligibleUserIds.length).toFixed(1) : '0'
 
-        // Determine shift type text for push
-        const SHIFT_NAMES = { TD1: 'TD1', TD2: 'TD2', ND: 'Nachtdienst', DBD: 'DBD' }
-        const shiftTypeText = urgentShifts?.length === 1
-            ? (SHIFT_NAMES[urgentShifts[0].type] || urgentShifts[0].type)
-            : `${urgentShifts?.length || 0} Dienste`
+        // Determine shift type text for push — use snapshot (deterministic), not urgent_since query (race with frontend RPC).
+        const SHIFT_NAMES: Record<string, string> = { TD1: 'TD1', TD2: 'TD2', ND: 'Nachtdienst', DBD: 'DBD' }
+        const shiftTypeText = snapshotShifts.length === 1
+            ? (SHIFT_NAMES[snapshotShifts[0].type] || snapshotShifts[0].type)
+            : `${snapshotShifts.length} Dienste`
 
         if (!subscriptions?.length) {
             console.log("No subscriptions found to notify.")


### PR DESCRIPTION
fixes #173

## Problem

Bei einer Krankmeldung bekamen Kolleg:innen Push-Nachrichten mit dem Titel:

> "0 Dienste am 19.04 muss nachbesetzt werden! Kannst du den Dienst übernehmen?"

"0 Dienste" ist natürlich Unsinn — wenn es keine Dienste gäbe, würde gar keine Push verschickt.

## Ursache

Race-Condition zwischen Frontend und Edge Function:

1. `RosterFeed.jsx` fügt den Krank-Datensatz in `absences` ein → das löst sofort den DB-Webhook zur Edge Function aus.
2. Erst **danach** ruft das Frontend das RPC `mark_shifts_urgent` auf, das `shifts.urgent_since` setzt.
3. Die Edge Function wartete 2 s und fragte dann Shifts mit `urgent_since IS NOT NULL` ab. Reicht das Sleep nicht (Cold-Start, Last), ist das Ergebnis leer.
4. Fallback-Text `"${urgentShifts.length || 0} Dienste"` → "0 Dienste".

## Fix

- Edge Function liest die Dienste jetzt direkt aus `record.planned_shifts_snapshot`, das vom selben `absences`-Insert stammt, der den Webhook ausgelöst hat — deterministisch, kein Race.
- Filter matching mit `RosterFeed.jsx`: `TEAM` und `FORTBILDUNG` werden ausgeschlossen (brauchen keine Nachbesetzung).
- Neuer Early-Return: Wenn der Snapshot nach Filterung leer ist, wird gar keine Push verschickt.
- 2-Sekunden-Sleep entfernt (war Symptombehandlung, reduziert zudem Function-Laufzeit).

Die bestehende `urgentShifts`-Query (Zeilen 178-183) bleibt erhalten — sie wird weiterhin zum Anlegen der `coverage_requests`/`coverage_votes` genutzt.

## Test plan

- [x] `npm run build` grün
- [x] `npm test` — 694 Tests grün
- [ ] **Nach Merge**: Edge Function `notify-sickness` in Supabase neu deployen (Cloudflare Pages deployt nur Frontend)
- [ ] Manuell: Krankmeldung an Tag mit Dienst → Push enthält korrekten Typ (z. B. "Nachtdienst am ...") oder korrekten Count ("2 Dienste am ...")
- [ ] Manuell: Krankmeldung an Tag ohne Dienste / nur TEAM → keine Push wird verschickt

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Eliminated processing delay, enabling faster shift notification delivery.

* **Bug Fixes**
  * Corrected shift information in notifications to accurately reflect planned shifts.
  * Enhanced filtering to exclude ineligible shift types from coverage requests.
  * Improved handling when no shifts require coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->