### PR TITLE
fix: RPC mark_shifts_urgent referenziert entfernte Spalte assigned_to (#175)

### DIFF
--- a/supabase/migrations/20260412200000_fix_mark_shifts_urgent_rpc.sql
+++ b/supabase/migrations/20260412200000_fix_mark_shifts_urgent_rpc.sql
@@ -1,0 +1,19 @@
+-- Fix mark_shifts_urgent RPC: remove reference to dropped shifts.assigned_to column.
+--
+-- Migration 20260404000000_remove_shifts_assigned_to.sql dropped shifts.assigned_to,
+-- but mark_shifts_urgent still referenced it in its UPDATE, causing every sick report
+-- to fail silently with "column assigned_to does not exist" and shifts never got
+-- urgent_since = NOW(). Now the RPC only sets urgent_since.
+
+CREATE OR REPLACE FUNCTION public.mark_shifts_urgent(p_shift_ids bigint[], p_user_id uuid)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public'
+AS $function$
+BEGIN
+    UPDATE shifts
+    SET urgent_since = NOW()
+    WHERE id = ANY(p_shift_ids);
+END;
+$function$;


### PR DESCRIPTION
fixes #175

## Problem

Nach einer Krankmeldung blieben die Dienste in der UI **nicht** als dringend markiert (`urgent_since = NULL`). Ursache: die RPC `mark_shifts_urgent` setzte ihr UPDATE auf `shifts.assigned_to` — diese Spalte wurde aber bereits am 2026-04-04 mit Migration [`20260404000000_remove_shifts_assigned_to.sql`](supabase/migrations/20260404000000_remove_shifts_assigned_to.sql) entfernt.

Jeder Aufruf brach also mit `ERROR: column "assigned_to" does not exist` ab. Der Fehler wurde im Frontend nur `console.error` geloggt, nicht sichtbar.

## Fix

Neue Migration `20260412200000_fix_mark_shifts_urgent_rpc.sql`: RPC auf `SET urgent_since = NOW()` reduziert. Parameter-Signatur (`p_shift_ids bigint[], p_user_id uuid`) bleibt unverändert, damit das Frontend ([RosterFeed.jsx:837-840](src/components/RosterFeed.jsx#L837-L840)) nicht angepasst werden muss.

## Status

- In Produktion bereits per `mcp__supabase__apply_migration` gepatcht
- Verifiziert mit Testaufruf auf die 19.04-Shifts → `urgent_since` korrekt gesetzt

## Test plan

- [x] Migration via `apply_migration` in Produktion angewendet
- [x] Manuell getestet: `SELECT mark_shifts_urgent(ARRAY[...], ...)` setzt `urgent_since`
- [ ] End-to-End: neue Krankmeldung erstellen → betroffene Dienste sind in UI als dringend gekennzeichnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored functionality to mark shifts as urgent with proper timestamp tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->